### PR TITLE
Fix Souvenir packages throwing constant errors

### DIFF
--- a/float.js
+++ b/float.js
@@ -149,7 +149,7 @@ const getAllFloats = function() {
 
             let listingData = steamListingData[id];
 
-            if (listingData.asset.market_actions == null || listingData.asset.market_actions.length === 0) {
+            if (listingData.asset.market_actions === null || listingData.asset.market_actions.length === 0) {
                 continue;
             }
 

--- a/float.js
+++ b/float.js
@@ -149,7 +149,7 @@ const getAllFloats = function() {
 
             let listingData = steamListingData[id];
 
-            if (listingData.asset.market_actions === null || listingData.asset.market_actions.length === 0) {
+            if (!listingData.asset.market_actions?.length) {
                 continue;
             }
 

--- a/float.js
+++ b/float.js
@@ -149,7 +149,7 @@ const getAllFloats = function() {
 
             let listingData = steamListingData[id];
 
-            if (listingData.asset.market_actions.length === 0) {
+            if (listingData.asset.market_actions == null || listingData.asset.market_actions.length === 0) {
                 continue;
             }
 


### PR DESCRIPTION
Fix Souvenir packages throwing constant errors ( TypeError: Cannot read properties of undefined (reading 'length') ) 
market_actions seem to be unavailable for these, so it throws the constant error that it cannot read the length of undefined.