### PR TITLE
Prevents Loading Item Row Injectors for Souvenir Packages

### DIFF
--- a/src/lib/components/market/item_row_wrapper.ts
+++ b/src/lib/components/market/item_row_wrapper.ts
@@ -86,6 +86,10 @@ export class ItemRowWrapper extends FloatElement {
     async connectedCallback() {
         super.connectedCallback();
 
+        if (!this.inspectLink) {
+            return;
+        }
+
         // Only add if they don't have Steam Inventory Helper
         if (!$J(this).parent().parent().find('.sih-inspect-magnifier').length) {
             inlineEasyInspect(
@@ -118,6 +122,10 @@ export class ItemRowWrapper extends FloatElement {
     }
 
     render() {
+        if (!this.inspectLink) {
+            return html``;
+        }
+
         if (this.itemInfo) {
             return html`
                 <div>

--- a/src/lib/components/market/skin_viewer.ts
+++ b/src/lib/components/market/skin_viewer.ts
@@ -71,6 +71,10 @@ export class SkinViewer extends FloatElement {
     }
 
     protected render(): HTMLTemplateResult {
+        if (!this.inspectLink) {
+            return html``;
+        }
+
         return html`
             <div class="btn-container">
                 <csgofloat-steam-button .text="${this.loadingIfApplicable("3D", Showing.MODEL)}"


### PR DESCRIPTION
Currently it tries to load the float for souvenir packages (which doesn't exist) and just returns errors.