### PR TITLE
Checks for Circular Deps in Github Build Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,3 +26,7 @@ jobs:
       run: |
         npm install
         npm run build
+    
+    - name: Check Circular Dependencies
+      run: |
+        npx --yes madge --circular --extensions ts ./


### PR DESCRIPTION
Typescript compiler won't error out in these instances and a circular dep can cause strange "X is undefined" errors that are hard to decipher.