### PR TITLE
Fix Loading Old Filters (from before v3)

### DIFF
--- a/src/lib/storage/store.ts
+++ b/src/lib/storage/store.ts
@@ -12,7 +12,12 @@ class Store {
             return null;
         }
 
-        return JSON.parse(a[key]) as T;
+        try {
+            return JSON.parse(a[key]) as T;
+        } catch (e) {
+            // Fallback if this is an old key not stored as JSON
+            return a[key] as T;
+        }
     }
 
     async set<T>(key: StorageKey | DynamicStorageKey, value: T): Promise<void> {


### PR DESCRIPTION
They are stored as their raw objects instead of JSON serialized strings, fallback to just returning the value if failed to parse.