### PR TITLE
Adds Trade Offer Inventory Fetch Fallback

### DIFF
--- a/src/lib/components/common/item_holder_metadata.ts
+++ b/src/lib/components/common/item_holder_metadata.ts
@@ -1,7 +1,7 @@
 import {FloatElement} from '../custom';
 import {html, css, HTMLTemplateResult} from 'lit';
 import {state} from 'lit/decorators.js';
-import {Asset} from '../../types/steam';
+import {rgAsset} from '../../types/steam';
 import {gFloatFetcher} from '../../services/float_fetcher';
 import {ItemInfo} from '../../bridge/handlers/fetch_inspect_info';
 import {formatFloatWithRank, formatSeed, getLowestRank} from '../../utils/skin';
@@ -38,7 +38,7 @@ export abstract class ItemHolderMetadata extends FloatElement {
         return $J(this).parent().attr('id')?.split('_')[2];
     }
 
-    abstract get asset(): Asset | undefined;
+    abstract get asset(): rgAsset | undefined;
     abstract get ownerSteamId(): string | undefined;
 
     get inspectLink(): string | undefined {

--- a/src/lib/components/inventory/inventory_item_holder_metadata.ts
+++ b/src/lib/components/inventory/inventory_item_holder_metadata.ts
@@ -1,5 +1,5 @@
 import {CustomElement, InjectAppend, InjectionMode} from '../injectors';
-import {Asset} from '../../types/steam';
+import {rgAsset} from '../../types/steam';
 import {ItemHolderMetadata} from '../common/item_holder_metadata';
 
 @CustomElement()
@@ -8,7 +8,7 @@ import {ItemHolderMetadata} from '../common/item_holder_metadata';
     InjectionMode.CONTINUOUS
 )
 export class InventoryItemHolderMetadata extends ItemHolderMetadata {
-    get asset(): Asset | undefined {
+    get asset(): rgAsset | undefined {
         if (!this.assetId) return;
 
         return g_ActiveInventory?.m_rgAssets[this.assetId]?.description;

--- a/src/lib/components/market/helpers.ts
+++ b/src/lib/components/market/helpers.ts
@@ -1,4 +1,4 @@
-import {Asset} from '../../types/steam';
+import {rgAsset} from '../../types/steam';
 import {ItemInfo} from '../../bridge/handlers/fetch_inspect_info';
 import {AppId, ContextId} from '../../types/steam_constants';
 
@@ -24,7 +24,7 @@ export function getMarketInspectLink(listingId: string): string | undefined {
  * @param itemInfo Item Info for the item from csgofloat API
  * @param asset Steam Asset for the item
  */
-export function inlineStickers(itemNameBlock: JQuery<Element>, itemInfo: ItemInfo, asset: Asset) {
+export function inlineStickers(itemNameBlock: JQuery<Element>, itemInfo: ItemInfo, asset: rgAsset) {
     if (!itemNameBlock) return;
 
     if (itemNameBlock.find('.csgofloat-stickers-container').length) {

--- a/src/lib/components/market/item_row_wrapper.ts
+++ b/src/lib/components/market/item_row_wrapper.ts
@@ -4,7 +4,7 @@ import {state} from 'lit/decorators.js';
 import {CustomElement, InjectAppend, InjectionMode} from '../injectors';
 import {FloatElement} from '../custom';
 import {cache} from 'decorator-cache-getter';
-import {Asset, ListingData} from '../../types/steam';
+import {rgAsset, ListingData} from '../../types/steam';
 import {gFloatFetcher} from '../../services/float_fetcher';
 import {ItemInfo} from '../../bridge/handlers/fetch_inspect_info';
 import {getMarketInspectLink, inlineEasyInspect, inlineStickers} from './helpers';
@@ -32,7 +32,7 @@ export class ItemRowWrapper extends FloatElement {
         return g_rgListingInfo[this.listingId!];
     }
 
-    get asset(): Asset | undefined {
+    get asset(): rgAsset | undefined {
         if (!this.listingInfo) return;
 
         return g_rgAssets[AppId.CSGO][ContextId.PRIMARY][this.listingInfo.asset.id!];

--- a/src/lib/components/market/skin_viewer.ts
+++ b/src/lib/components/market/skin_viewer.ts
@@ -8,7 +8,7 @@ import {ClientSend} from '../../bridge/client';
 import '../common/ui/steam-button';
 import {cache} from 'decorator-cache-getter';
 import {getMarketInspectLink} from './helpers';
-import {Asset, ListingData} from '../../types/steam';
+import {rgAsset, ListingData} from '../../types/steam';
 import {AppId, ContextId} from '../../types/steam_constants';
 import {isSkin} from '../../utils/skin';
 
@@ -58,7 +58,7 @@ export class SkinViewer extends FloatElement {
         return g_rgListingInfo[this.listingId!];
     }
 
-    get asset(): Asset | undefined {
+    get asset(): rgAsset | undefined {
         if (!this.listingInfo) return;
 
         return g_rgAssets[AppId.CSGO][ContextId.PRIMARY][this.listingInfo.asset.id!];

--- a/src/lib/components/trade_offer/trade_item_holder_metadata.ts
+++ b/src/lib/components/trade_offer/trade_item_holder_metadata.ts
@@ -1,5 +1,5 @@
 import {CustomElement, InjectAppend, InjectionMode} from '../injectors';
-import {Asset, UserSomeone} from '../../types/steam';
+import {rgAsset, UserSomeone} from '../../types/steam';
 import {ItemHolderMetadata} from '../common/item_holder_metadata';
 import {AppId, ContextId} from '../../types/steam_constants';
 
@@ -26,7 +26,7 @@ export class TradeItemHolderMetadata extends ItemHolderMetadata {
         return this.owningUser?.strSteamId;
     }
 
-    get asset(): Asset | undefined {
+    get asset(): rgAsset | undefined {
         if (!this.assetId) return;
 
         if (!this.owningUser) return;
@@ -34,7 +34,7 @@ export class TradeItemHolderMetadata extends ItemHolderMetadata {
         return TradeItemHolderMetadata.getAssetFromUser(this.owningUser, this.assetId);
     }
 
-    private static getAssetFromUser(user: UserSomeone, assetId: string): Asset | undefined {
+    private static getAssetFromUser(user: UserSomeone, assetId: string): rgAsset | undefined {
         if (user.rgContexts[AppId.CSGO][ContextId.PRIMARY].inventory?.rgInventory[assetId]) {
             const inventory = user.rgContexts[AppId.CSGO][ContextId.PRIMARY].inventory;
             return inventory?.rgInventory[assetId];

--- a/src/lib/page_scripts/trade_offer.ts
+++ b/src/lib/page_scripts/trade_offer.ts
@@ -4,4 +4,29 @@ import '../components/trade_offer/auto_fill';
 
 init('src/lib/page_scripts/trade_offer.js', main);
 
-async function main() {}
+async function main() {
+    injectInventoryFallback();
+}
+
+function injectInventoryFallback() {
+    /**
+     * Valve had the great idea to rate limit user's requests to their own
+     * inventory. As a result, some people can't send a trade offer since
+     * they can't load their inventory.
+     *
+     * This mitigation uses the API Key fallback method instead, which only
+     * works if they have an Steam Web API key on their account.
+     */
+    CUserYou.prototype.g_OnLoadInventoryComplete = CUserYou.prototype.OnLoadInventoryComplete;
+
+    CUserYou.prototype.OnLoadInventoryComplete = function OnLoadInventoryComplete(transport, appId, contextId) {
+        if (transport.responseJSON?.success) {
+            // Original call was successful, nothing more to do
+            this.g_OnLoadInventoryComplete(transport, appId, contextId);
+            return;
+        }
+
+        // Call failed... try to fallback to the API Key method.
+        // TODO: Fallback
+    };
+}

--- a/src/lib/page_scripts/trade_offer.ts
+++ b/src/lib/page_scripts/trade_offer.ts
@@ -2,23 +2,12 @@ import {init} from './utils';
 import '../components/trade_offer/trade_item_holder_metadata';
 import '../components/trade_offer/auto_fill';
 import {ClassIdAndInstanceId, rgDescription, rgInventoryAsset, TradeInventory} from '../types/steam';
+import {fetchRegisteredSteamAPIKey} from '../utils/key';
 
 init('src/lib/page_scripts/trade_offer.js', main);
 
 async function main() {
     injectInventoryFallback();
-}
-
-async function fetchRegisteredSteamAPIKey(): Promise<string> {
-    const pageResponse = await fetch('https://steamcommunity.com/dev/apikey');
-    const pageText = await pageResponse.text();
-
-    const match = pageText.match(/Key: ([0-9A-Z]{32})[^0-9A-Z]/);
-    if (match) {
-        return match[1];
-    }
-
-    throw new Error('failed to find registered API key');
 }
 
 interface KeyInventoryResponse {

--- a/src/lib/page_scripts/trade_offer.ts
+++ b/src/lib/page_scripts/trade_offer.ts
@@ -1,6 +1,7 @@
 import {init} from './utils';
 import '../components/trade_offer/trade_item_holder_metadata';
 import '../components/trade_offer/auto_fill';
+import {ClassIdAndInstanceId, rgDescription, rgInventoryAsset, TradeInventory} from '../types/steam';
 
 init('src/lib/page_scripts/trade_offer.js', main);
 
@@ -8,25 +9,122 @@ async function main() {
     injectInventoryFallback();
 }
 
+async function fetchRegisteredSteamAPIKey(): Promise<string> {
+    const pageResponse = await fetch('https://steamcommunity.com/dev/apikey');
+    const pageText = await pageResponse.text();
+
+    const match = pageText.match(/Key: ([0-9A-Z]{32})[^0-9A-Z]/);
+    if (match) {
+        return match[1];
+    }
+
+    throw new Error('failed to find registered API key');
+}
+
+interface KeyInventoryResponse {
+    response: {
+        assets?: rgInventoryAsset[];
+        descriptions: rgDescription[];
+        total_inventory_count: number;
+    };
+}
+
+/**
+ * Converts the API Key inventory response to match the "Trade" inventory
+ * response for Steam's client code.
+ */
+function convertKeyInventoryIntoTradeInventory(raw: KeyInventoryResponse): TradeInventory {
+    // Populate missing fields
+    raw.response.assets?.forEach((asset, index) => {
+        asset.id = asset.assetid!;
+        asset.pos = index + 1;
+        asset.hide_in_china = 0;
+    });
+
+    const rgInventory = raw.response.assets!.reduce((acc, v) => {
+        acc[v.id] = v;
+        return acc;
+    }, {} as {[k: string]: rgInventoryAsset});
+
+    const rgDescriptions = raw.response.descriptions?.reduce((acc, v) => {
+        (v.tags || []).forEach((tag) => {
+            // # Valve consistency, this field was renamed
+            tag.name = tag.localized_tag_name;
+        });
+
+        acc[`${v.classid}_${v.instanceid}` as ClassIdAndInstanceId] = v;
+
+        return acc;
+    }, {} as {[k: ClassIdAndInstanceId]: rgDescription});
+
+    return {
+        more: false,
+        more_start: false,
+        rgCurrency: [],
+        rgDescriptions,
+        rgInventory,
+        success: true,
+    };
+}
+
+async function fetchInventoryWithAPIKey(): Promise<TradeInventory> {
+    const key = await fetchRegisteredSteamAPIKey();
+
+    const resp = await fetch(
+        `https://api.steampowered.com/IEconService/GetInventoryItemsWithDescriptions/v1/?appid=730&contextid=2&count=5000&get_descriptions=true&key=${key}&steamid=${UserYou?.strSteamId}`
+    );
+    if (!resp.ok) {
+        throw new Error('key inventory fetch response was not OK');
+    }
+
+    const data = (await resp.json()) as KeyInventoryResponse;
+
+    // Sometimes Steam likes to return an empty response...
+    if (!data.response.assets?.length) {
+        throw new Error('key inventory response had no assets');
+    }
+
+    return convertKeyInventoryIntoTradeInventory(data);
+}
+
 function injectInventoryFallback() {
     /**
-     * Valve had the great idea to rate limit user's requests to their own
-     * inventory. As a result, some people can't send a trade offer since
-     * they can't load their inventory.
+     * Valve can rate limit user's requests to their own inventory. As a result,
+     * some people can't send a trade offer since they can't load their inventory.
      *
      * This mitigation uses the API Key fallback method instead, which only
-     * works if they have an Steam Web API key on their account.
+     * works if they have a Steam Web API key on their account.
      */
-    CUserYou.prototype.g_OnLoadInventoryComplete = CUserYou.prototype.OnLoadInventoryComplete;
+    const g_ContinueFullInventoryRequestIfNecessary = ContinueFullInventoryRequestIfNecessary;
 
-    CUserYou.prototype.OnLoadInventoryComplete = function OnLoadInventoryComplete(transport, appId, contextId) {
-        if (transport.responseJSON?.success) {
-            // Original call was successful, nothing more to do
-            this.g_OnLoadInventoryComplete(transport, appId, contextId);
-            return;
+    ContinueFullInventoryRequestIfNecessary = async function (
+        transport: JQuery.jqXHR,
+        mergedResponse: any,
+        strUrl: string,
+        oParams: any,
+        fOnSuccess: () => any,
+        fOnFailure: () => any,
+        fOnComplete: () => any
+    ) {
+        if (strUrl.startsWith(g_strInventoryLoadURL!) && transport.status === 429) {
+            // User was rate limited... try the fallback.
+            try {
+                const newInventory = await fetchInventoryWithAPIKey();
+                transport.responseJSON = newInventory;
+            } catch (e) {
+                console.debug('failed to fetch fallback inventory via key', e);
+            }
         }
 
-        // Call failed... try to fallback to the API Key method.
-        // TODO: Fallback
+        // Call upstream
+        return g_ContinueFullInventoryRequestIfNecessary(
+            transport,
+            mergedResponse,
+            strUrl,
+            oParams,
+            fOnSuccess,
+            fOnFailure,
+            fOnComplete
+        );
     };
 }

--- a/src/lib/types/steam.d.ts
+++ b/src/lib/types/steam.d.ts
@@ -183,15 +183,6 @@ export interface UserSomeone {
     findAsset: (appId: AppId, contextId: ContextId, itemId: string) => rgAsset;
 }
 
-export interface CUserYou {
-    prototype: {
-        OnLoadInventoryComplete: (transport: JQuery.jqXHR, appId: AppId, ContentId: ContextId) => void;
-
-        // Annotated by CSGOFloat
-        g_OnLoadInventoryComplete: (transport: JQuery.jqXHR, appId: AppId, ContentId: ContextId) => void;
-    };
-}
-
 export interface CurrentTradeAsset {
     amount: number;
     appid: AppId;
@@ -241,7 +232,6 @@ declare global {
     const CInventory: CInventory;
     const UserThem: UserSomeone | undefined; // Only populated on create offer pages
     const UserYou: UserSomeone | undefined; // Only populated on create offer pages
-    const CUserYou: CUserYou; // Only populated on create offer pages
     const g_strInventoryLoadURL: string | undefined; // Only populated on create offer pages
     let ContinueFullInventoryRequestIfNecessary: (
         transport: JQuery.jqXHR,

--- a/src/lib/types/steam.d.ts
+++ b/src/lib/types/steam.d.ts
@@ -61,6 +61,7 @@ export interface rgDescription {
     type: string;
     tags?: {
         category: string;
+        name?: string;
         internal_name: string;
         localized_category_name?: string;
         localized_tag_name?: string;
@@ -91,6 +92,7 @@ export interface rgInventoryAsset {
     id: string;
     instance_id: InstanceId;
     pos: number;
+    assetid?: string; // Only populated in some endpoints...equivalent to `id`
 }
 
 export interface InventoryAsset {
@@ -210,15 +212,14 @@ export interface CurrentTradeStatus {
     };
 }
 
-type ClassIdAndInstanceId = `${ClassId}_${InstanceId}`;
-
-export interface TradeInventoryDescription {}
+export type ClassIdAndInstanceId = `${ClassId}_${InstanceId}`;
 
 export interface TradeInventory {
     more: boolean;
     more_start: boolean;
     rgDescriptions: {[k: ClassIdAndInstanceId]: rgDescription};
-    rgInventory: {[k: ClassId]: rgInventoryAsset};
+    rgInventory: {[k: string]: rgInventoryAsset};
+    rgCurrency: any[];
     success: boolean;
 }
 
@@ -242,6 +243,15 @@ declare global {
     const UserYou: UserSomeone | undefined; // Only populated on create offer pages
     const CUserYou: CUserYou; // Only populated on create offer pages
     const g_strInventoryLoadURL: string | undefined; // Only populated on create offer pages
+    let ContinueFullInventoryRequestIfNecessary: (
+        transport: JQuery.jqXHR,
+        mergedResponse: any,
+        strUrl: string,
+        oParams: any,
+        fOnSuccess: () => any,
+        fOnFailure: () => any,
+        fOnComplete: () => any
+    ) => void; // Only populated on create offer pages
     const MoveItemToTrade: (el: HTMLElement) => void; // Only populated on create offer pages
     const g_rgCurrentTradeStatus: CurrentTradeStatus;
 }

--- a/src/lib/types/steam.d.ts
+++ b/src/lib/types/steam.d.ts
@@ -181,6 +181,15 @@ export interface UserSomeone {
     findAsset: (appId: AppId, contextId: ContextId, itemId: string) => rgAsset;
 }
 
+export interface CUserYou {
+    prototype: {
+        OnLoadInventoryComplete: (transport: JQuery.jqXHR, appId: AppId, ContentId: ContextId) => void;
+
+        // Annotated by CSGOFloat
+        g_OnLoadInventoryComplete: (transport: JQuery.jqXHR, appId: AppId, ContentId: ContextId) => void;
+    };
+}
+
 export interface CurrentTradeAsset {
     amount: number;
     appid: AppId;
@@ -231,16 +240,8 @@ declare global {
     const CInventory: CInventory;
     const UserThem: UserSomeone | undefined; // Only populated on create offer pages
     const UserYou: UserSomeone | undefined; // Only populated on create offer pages
+    const CUserYou: CUserYou; // Only populated on create offer pages
     const g_strInventoryLoadURL: string | undefined; // Only populated on create offer pages
-    let RequestFullInventory:
-        | ((
-              strUrl: string,
-              oParams: {[k: string]: string},
-              fOnSuccess: (response: TradeInventory) => any,
-              fOnFailure: (t: JQuery.Transport) => any,
-              fOnComplete: (response: TradeInventory) => any
-          ) => any)
-        | undefined; // Only populated on create offer pages
     const MoveItemToTrade: (el: HTMLElement) => void; // Only populated on create offer pages
     const g_rgCurrentTradeStatus: CurrentTradeStatus;
 }

--- a/src/lib/utils/key.ts
+++ b/src/lib/utils/key.ts
@@ -1,0 +1,16 @@
+/**
+ * Returns the registered Steam Web API key for the user, if it exists.
+ *
+ * If the key cannot be found, throws an error.
+ */
+export async function fetchRegisteredSteamAPIKey(): Promise<string> {
+    const pageResponse = await fetch('https://steamcommunity.com/dev/apikey');
+    const pageText = await pageResponse.text();
+
+    const match = pageText.match(/Key: ([0-9A-Z]{32})[^0-9A-Z]/);
+    if (match) {
+        return match[1];
+    }
+
+    throw new Error('failed to find registered API key');
+}

--- a/src/lib/utils/skin.ts
+++ b/src/lib/utils/skin.ts
@@ -1,4 +1,4 @@
-import {Asset} from '../types/steam';
+import {rgAsset} from '../types/steam';
 import {ItemInfo} from '../bridge/handlers/fetch_inspect_info';
 import {getDopplerPhase, hasDopplerPhase} from './dopplers';
 import {html, TemplateResult} from 'lit';
@@ -103,7 +103,7 @@ export function renderClickableRank(info: ItemInfo): TemplateResult<1> {
     </a>`;
 }
 
-export function isSkin(asset: Asset): boolean {
+export function isSkin(asset: rgAsset): boolean {
     return asset.tags
         ? asset.tags.some((a) => a.category === 'Weapon' || (a.category === 'Type' && a.internal_name === 'Type_Hands'))
         : ['★', 'Factory New', 'Minimal Wear', 'Field-Tested', 'Well-Worn', 'Battle-Scarred'].some((keyword) =>


### PR DESCRIPTION
Steam can rate limit access to your own inventory within the trade offer page. If this occurs, you won't be able to send trade offers.

As a fallback, this PR checks if the user has a registered Steam Web API Key, and if so, sends an inventory request via. an alternate method. This involves hooking some functions within the regular inventory fetching flow on the page.

Of note, this _does not_ register an API Key for the user if they don't have one.