### PR TITLE
Update steam.d.ts

### DIFF
--- a/src/lib/types/steam.d.ts
+++ b/src/lib/types/steam.d.ts
@@ -46,6 +46,7 @@ export interface rgDescription {
         type: string;
         value: string;
     }[];
+    fraudwarnings?: string[];
     icon_url: string;
     icon_url_large: string;
     instanceid: string;


### PR DESCRIPTION
Added fraudwarnings property to asset descriptions. This is for example used in CS to show the custom name of a skin.