### PR TITLE
Enables Inventory Fallback for 400/500 HTTP Errors

### DIFF
--- a/src/lib/page_scripts/trade_offer.ts
+++ b/src/lib/page_scripts/trade_offer.ts
@@ -95,7 +95,7 @@ function injectInventoryFallback() {
         fOnFailure: () => any,
         fOnComplete: () => any
     ) {
-        if (strUrl.startsWith(g_strInventoryLoadURL!) && transport.status === 429) {
+        if (strUrl.startsWith(g_strInventoryLoadURL!) && transport.status !== 200) {
             // User was rate limited... try the fallback.
             try {
                 const newInventory = await fetchInventoryWithAPIKey();

--- a/src/lib/page_scripts/trade_offer.ts
+++ b/src/lib/page_scripts/trade_offer.ts
@@ -95,7 +95,7 @@ function injectInventoryFallback() {
         fOnFailure: () => any,
         fOnComplete: () => any
     ) {
-        if (strUrl.startsWith(g_strInventoryLoadURL!) && transport.status !== 200) {
+        if (strUrl.startsWith(g_strInventoryLoadURL!) && transport.status >= 400) {
             // User was rate limited... try the fallback.
             try {
                 const newInventory = await fetchInventoryWithAPIKey();


### PR DESCRIPTION
Previously only for `429` rate limit, but it looks like some people hit other error codes.

This PR activates the fallback for any client or server error.