### PR TITLE
Temporarily Disables Changing Page Size Automatically

### DIFF
--- a/src/lib/components/market/page_size.ts
+++ b/src/lib/components/market/page_size.ts
@@ -51,7 +51,7 @@ export class PageSize extends FloatElement {
     changePageSize(newSize: number) {
         this.selectedSize = newSize;
         g_oSearchResults.m_cPageSize = newSize;
-        g_oSearchResults.GoToPage(0, false);
+        g_oSearchResults.GoToPage(0, true);
 
         Set<number>(PAGE_SIZE, newSize);
     }


### PR DESCRIPTION
See https://twitter.com/csfloatcom/status/1724684828388610091

Steam Market has a regression where you can't use pagination _at all_ on the Steam Market.

#184 