### PR TITLE
Fixes Inventory Picker Disable When Wrong Context Selected

### DIFF
--- a/src/lib/components/trade_offer/auto_fill.ts
+++ b/src/lib/components/trade_offer/auto_fill.ts
@@ -272,6 +272,15 @@ export class AutoFill extends FloatElement {
             this.disableInventoryPicker();
         }
 
+        if (tradesToBuyer.length > 0 && g_ActiveInventory?.appid !== AppId.CSGO) {
+            // Default to CS inventory
+            try {
+                ShowItemInventory(AppId.CSGO, ContextId.PRIMARY);
+            } catch (e) {
+                console.error(e);
+            }
+        }
+
         return html`
             ${this.showAutoFillInfoDialog(tradesToBuyer)} ${this.showPermissionWarningDialog(tradesToBuyer)}
             ${this.renderBulkAutoFillDialog(tradesToBuyer)} ${tradesToBuyer.map((e) => this.renderAutoFillDialog(e))}
@@ -284,16 +293,16 @@ export class AutoFill extends FloatElement {
             return;
         }
 
-        const elem = document.getElementsByClassName('trade_box_contents');
-        if (!elem || elem.length === 0) {
+        const elem = document.getElementById('inventories');
+        if (!elem) {
             return;
         }
 
         // @ts-ignore
-        elem.item(0)?.style.opacity = '0.5';
+        elem.style.opacity = '0.5';
 
         // @ts-ignore
-        elem.item(0)?.style.pointerEvents = 'none';
+        elem.style.pointerEvents = 'none';
     }
 
     autoFillAll(trades: Trade[]) {

--- a/src/lib/types/steam.d.ts
+++ b/src/lib/types/steam.d.ts
@@ -122,6 +122,7 @@ export interface CInventory {
     m_owner?: mOwner;
     owner?: mOwner;
     selectedItem?: InventoryAsset;
+    appid?: number;
 }
 
 export interface CAjaxPagingControls {
@@ -182,6 +183,7 @@ export interface UserSomeone {
     };
     strSteamId: string;
     findAsset: (appId: AppId, contextId: ContextId, itemId: string) => rgAsset;
+    ReloadInventory: (appId: AppId, contextId: ContextId) => void;
 }
 
 export interface CurrentTradeAsset {
@@ -245,6 +247,7 @@ declare global {
     ) => void; // Only populated on create offer pages
     const MoveItemToTrade: (el: HTMLElement) => void; // Only populated on create offer pages
     const g_rgCurrentTradeStatus: CurrentTradeStatus;
+    const ShowItemInventory: (appID: AppId, contextID: ContextId, AssetID?: number) => void;
 }
 
 export {};


### PR DESCRIPTION
If you had the wrong context selected, you wouldn't be able to fix it.