### PR TITLE
Fix: Line Breaks for Floats with Rank

### DIFF
--- a/src/lib/components/common/item_holder_metadata.ts
+++ b/src/lib/components/common/item_holder_metadata.ts
@@ -22,6 +22,7 @@ export abstract class ItemHolderMetadata extends FloatElement {
                 bottom: 3px;
                 right: 3px;
                 font-size: 12px;
+                text-align: right;
             }
 
             .seed {


### PR DESCRIPTION
## Description

When an item has a ranked float, the current line break causes a misalignment of the whole text.
This PR fixes this by making sure the text is always right-aligned.

## Screenshots
Before:
<img width="211" alt="Screenshot 2025-03-19 at 12 08 18" src="https://github.com/user-attachments/assets/d698ff15-7e80-40e5-b7f3-9978b8cff936" />
After:
<img width="211" alt="Screenshot 2025-03-19 at 12 07 54" src="https://github.com/user-attachments/assets/44b7a66e-5a3c-4405-9acd-e661b00df431" />
