### PR TITLE
Sellable Highlight Charms

### DIFF
--- a/src/lib/utils/skin.ts
+++ b/src/lib/utils/skin.ts
@@ -107,7 +107,7 @@ export function renderClickableRank(info: ItemInfo): TemplateResult<1> {
 export function isSellableOnCSFloat(asset: rgAsset): boolean {
     return (
         isSkin(asset) ||
-        isCharm(asset)||
+        isCharm(asset) ||
         isAgent(asset) ||
         isSticker(asset) ||
         isPatch(asset) ||


### PR DESCRIPTION
Highlight Charms have been sellable on CSFloat for a while now. 
We should allow selling them via the extension as well.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the exclusion for Highlight Charms in `isSellableOnCSFloat`, making all charms (including highlight) sellable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c19e8db8308916dd209eb78ef007133cf972c2da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->