### PR TITLE
Add Doppler Phase to Search Link

### DIFF
--- a/src/lib/components/inventory/list_item_modal.ts
+++ b/src/lib/components/inventory/list_item_modal.ts
@@ -91,7 +91,7 @@ export class ListItemModal extends FloatElement {
         if (paintindex && hasDopplerPhase(paintindex)) {
             extendedMHN += ` [${getDopplerPhase(paintindex)}]`;
         }
-        
+
         return `https://csfloat.com/search?market_hash_name=${encodeURIComponent(extendedMHN)}`;
     }
 


### PR DESCRIPTION
As our market searches now support an extended MHN format, we can switch to get more accurate results for Doppler knives.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances the listing modal's search link to include Doppler phase when applicable and makes itemInfo optional.
> 
> - **Frontend**:
>   - **List item modal** (`src/lib/components/inventory/list_item_modal.ts`):
>     - Enhance `searchUrl` to append Doppler phase to `market_hash_name` when applicable using `hasDopplerPhase`/`getDopplerPhase`, then URL-encode the extended value.
>     - Make `itemInfo` optional to safely access `paintindex`.
>     - Import Doppler utilities from `utils/dopplers`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1521a3152b06aba10fc902bd4b3febc95f5e503e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->