### PR TITLE
Adds Additional Trade History Params

### DIFF
--- a/src/lib/alarms/trade_history.ts
+++ b/src/lib/alarms/trade_history.ts
@@ -1,13 +1,13 @@
-import { SlimTrade } from '../types/float_market';
-import { TradeHistoryStatus, TradeHistoryType } from '../bridge/handlers/trade_history_status';
-import { AppId, TradeOfferState, TradeStatus } from '../types/steam_constants';
-import { clearAccessTokenFromStorage, getAccessToken } from './access_token';
+import {SlimTrade} from '../types/float_market';
+import {TradeHistoryStatus, TradeHistoryType} from '../bridge/handlers/trade_history_status';
+import {AppId, TradeOfferState, TradeStatus} from '../types/steam_constants';
+import {clearAccessTokenFromStorage, getAccessToken} from './access_token';
 
 export async function pingTradeHistory(
     pendingTrades: SlimTrade[],
     steamID?: string | null
 ): Promise<TradeHistoryStatus[]> {
-    const { history, type } = await getTradeHistory();
+    const {history, type} = await getTradeHistory();
 
     // premature optimization in case it's 100 trades
     const assetsToFind = pendingTrades.reduce(
@@ -15,7 +15,7 @@ export async function pingTradeHistory(
             acc[e.contract.item.asset_id] = e;
             return acc;
         },
-        {} as { [key: string]: SlimTrade }
+        {} as {[key: string]: SlimTrade}
     );
 
     // We only want to send history that is relevant to verifying trades on CSFloat
@@ -42,17 +42,17 @@ export async function pingTradeHistory(
         return history;
     }
 
-    await TradeHistoryStatus.handleRequest({ history: historyForCSFloat, type }, {});
+    await TradeHistoryStatus.handleRequest({history: historyForCSFloat, type}, {});
 
     return history;
 }
 
-async function getTradeHistory(): Promise<{ history: TradeHistoryStatus[]; type: TradeHistoryType }> {
+async function getTradeHistory(): Promise<{history: TradeHistoryStatus[]; type: TradeHistoryType}> {
     try {
         const history = await getTradeHistoryFromAPI(250);
         if (history.length > 0) {
             // Hedge in case this endpoint gets killed, only return if there are results, fallback to HTML parser
-            return { history, type: TradeHistoryType.API };
+            return {history, type: TradeHistoryType.API};
         } else {
             throw new Error('failed to get trade history');
         }
@@ -60,7 +60,7 @@ async function getTradeHistory(): Promise<{ history: TradeHistoryStatus[]; type:
         await clearAccessTokenFromStorage();
         // Fallback to HTML parsing
         const history = await getTradeHistoryFromHTML();
-        return { history, type: TradeHistoryType.HTML };
+        return {history, type: TradeHistoryType.HTML};
     }
 }
 
@@ -149,12 +149,12 @@ export async function getTradeHistoryFromAPI(
                 received_assets: (e.assets_received || [])
                     .filter((e) => e.appid === AppId.CSGO)
                     .map((e) => {
-                        return { asset_id: e.assetid, new_asset_id: e.new_assetid };
+                        return {asset_id: e.assetid, new_asset_id: e.new_assetid};
                     }),
                 given_assets: (e.assets_given || [])
                     .filter((e) => e.appid === AppId.CSGO)
                     .map((e) => {
-                        return { asset_id: e.assetid, new_asset_id: e.new_assetid };
+                        return {asset_id: e.assetid, new_asset_id: e.new_assetid};
                     }),
                 trade_id: e.tradeid,
                 time_settlement: e.time_settlement,
@@ -209,9 +209,9 @@ function parseTradeHistoryHTML(body: string): TradeHistoryStatus[] {
         const [text, index, type, assetId] = match;
         const tradeIndex = parseInt(index);
         if (type === 'received') {
-            statuses[tradeIndex].received_assets.push({ asset_id: assetId });
+            statuses[tradeIndex].received_assets.push({asset_id: assetId});
         } else if (type === 'given') {
-            statuses[tradeIndex].given_assets.push({ asset_id: assetId });
+            statuses[tradeIndex].given_assets.push({asset_id: assetId});
         }
     }
 

--- a/src/lib/bridge/handlers/fetch_trade_history.ts
+++ b/src/lib/bridge/handlers/fetch_trade_history.ts
@@ -1,7 +1,7 @@
-import { SimpleHandler } from './main';
-import { RequestType } from './types';
-import { TradeHistoryStatus } from './trade_history_status';
-import { getTradeHistoryFromAPI } from '../../alarms/trade_history';
+import {SimpleHandler} from './main';
+import {RequestType} from './types';
+import {TradeHistoryStatus} from './trade_history_status';
+import {getTradeHistoryFromAPI} from '../../alarms/trade_history';
 
 export interface FetchTradeHistoryRequest {
     max_trades: number;

--- a/src/lib/bridge/handlers/trade_history_status.ts
+++ b/src/lib/bridge/handlers/trade_history_status.ts
@@ -1,6 +1,6 @@
-import { SimpleHandler } from './main';
-import { RequestType } from './types';
-import { environment } from '../../../environment';
+import {SimpleHandler} from './main';
+import {RequestType} from './types';
+import {environment} from '../../../environment';
 
 export interface TradeHistoryAsset {
     asset_id: string;
@@ -28,7 +28,7 @@ export interface TradeHistoryStatusRequest {
     type?: TradeHistoryType;
 }
 
-export interface TradeHistoryStatusResponse { }
+export interface TradeHistoryStatusResponse {}
 
 export const TradeHistoryStatus = new SimpleHandler<TradeHistoryStatusRequest, TradeHistoryStatusResponse>(
     RequestType.TRADE_HISTORY_STATUS,


### PR DESCRIPTION
Adds all known parameters supported by the `GetTradeHistory` endpoint on Steam.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional query params to trade history fetching and includes time_init in trade history responses.
> 
> - **Trade history API**:
>   - Expand `getTradeHistoryFromAPI(maxTrades, opts)` to accept optional params: `startAfterTime`, `startAfterTradeID`, `navigatingBack`, `getDescriptions`, `includeFailed`, `includeTotal`, `language`, and build the request URL accordingly.
>   - Map API response to include `time_init` in `TradeHistoryStatus`.
> - **Bridge handlers**:
>   - Extend `FetchTradeHistoryRequest` with the same optional params and pass them to `getTradeHistoryFromAPI`.
>   - Update `TradeHistoryStatus` interface to include `time_init`; HTML parser initializes it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40800662e558fe6a39032a2f453188800f2a62ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->