### PR TITLE
Fix: Selectors for `SelectedItemInfo`

### DIFF
--- a/src/lib/components/inventory/selected_item_info.ts
+++ b/src/lib/components/inventory/selected_item_info.ts
@@ -32,8 +32,14 @@ import './list_item_modal';
  * item click.
  */
 @CustomElement()
-@InjectAfter('div.app730#iteminfo0_content .item_desc_description div.item_desc_game_info', InjectionMode.CONTINUOUS)
-@InjectAfter('div.app730#iteminfo1_content .item_desc_description div.item_desc_game_info', InjectionMode.CONTINUOUS)
+@InjectAfter(
+    'div#iteminfo0 div:has(> a[href^="https://store.steampowered.com/app/730/CounterStrike_2"] > img)',
+    InjectionMode.CONTINUOUS
+)
+@InjectAfter(
+    'div#iteminfo1 div:has(> a[href^="https://store.steampowered.com/app/730/CounterStrike_2"] > img)',
+    InjectionMode.CONTINUOUS
+)
 export class SelectedItemInfo extends FloatElement {
     static styles = [
         ...FloatElement.styles,


### PR DESCRIPTION
Closes #358.

Valve reworked some components on the site in React with a CSS pre-compiler, which generates random class names.

This PR switches to an alternative approach of determining the correct position to minimize the reliance on class names.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches SelectedItemInfo injection points to robust :has-based selectors targeting CS2 item info containers.
> 
> - **Inventory UI**:
>   - Update `@InjectAfter` selectors in `src/lib/components/inventory/selected_item_info.ts` from class-based paths to `:has(...)` selectors targeting `div#iteminfo0`/`div#iteminfo1` with CS2 app link images, ensuring correct injection location.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d06eeea9f320018b67b11f6c7c28fde1aec82ded. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->