### PR TITLE
Fix: Hide Floatbar on Missing Min / Max Values

### DIFF
--- a/src/lib/components/inventory/selected_item_info.ts
+++ b/src/lib/components/inventory/selected_item_info.ts
@@ -156,7 +156,12 @@ export class SelectedItemInfo extends FloatElement {
     }
 
     renderFloatBar(): TemplateResult<1> {
-        if (!this.itemInfo || !this.itemInfo.floatvalue || this.itemInfo.min === undefined || this.itemInfo.max === undefined) {
+        if (
+            !this.itemInfo ||
+            !this.itemInfo.floatvalue ||
+            this.itemInfo.min === undefined ||
+            this.itemInfo.max === undefined
+        ) {
             return html``;
         }
 


### PR DESCRIPTION
## Bug

Example: M4A1-S Solitude
<img width="648" height="138" alt="image" src="https://github.com/user-attachments/assets/8aa451b5-6787-44f9-8828-084f1a9c8018" />

## Description

Hides the `FloatBar` if either the `min` or `max` value for the float range is missing.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Do not render the float bar if `min` or `max` float values are missing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce3c607177d19621829897093165806158300931. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->