### PR TITLE
Fix: Display Applied Sticker Slabs on Market Pages

### DIFF
--- a/src/lib/components/market/sticker_display.ts
+++ b/src/lib/components/market/sticker_display.ts
@@ -196,7 +196,10 @@ export class StickerDisplay extends FloatElement {
     private loadKeychains(): void {
         const description = this.keychainDescription;
 
-        if (description?.type !== 'html' || (description.value.includes('sticker') && !description.value.includes('Sticker Slab'))) {
+        if (
+            description?.type !== 'html' ||
+            (description.value.includes('sticker') && !description.value.includes('Sticker Slab'))
+        ) {
             this.keychains = [];
             return;
         }


### PR DESCRIPTION
Fixes the parsing for Sticker Slabs in our custom sticker display on market pages:
<img width="491" height="94" alt="Screenshot 2026-01-26 at 16 55 59" src="https://github.com/user-attachments/assets/855790e5-5e26-40d9-9d79-f8eb945f8838" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Keychain parsing:** Updates `loadKeychains` to allow HTML descriptions containing `Sticker Slab` while still excluding regular `sticker` entries, enabling Sticker Slab rendering.
> - **Value handling:** In `renderAppliedItem`, only renders the `item-value` span when `item.value` is present; and keychain value formatter now returns an empty string when no pattern exists (e.g., Sticker Slabs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac871ca0af24b8dc14d26ce7eaa296cf4fca041e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->