### PR TITLE
Increases Limit for Trades Fetched

### DIFF
--- a/src/lib/alarms/csfloat_trade_pings.ts
+++ b/src/lib/alarms/csfloat_trade_pings.ts
@@ -30,7 +30,7 @@ export async function pingTradeStatus(expectedSteamID?: string) {
 
     let pendingTrades: SlimTrade[];
     try {
-        const resp = await FetchSlimTrades.handleRequest({limit: 3000}, {});
+        const resp = await FetchSlimTrades.handleRequest({limit: 5000}, {});
         pendingTrades = resp.trades;
     } catch (e) {
         console.error(e);


### PR DESCRIPTION
Ref CSF-425

DO_NOT_SUBMIT=Wait for BE release to propagate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change to a fetch limit; main risk is increased API load/timeouts when fetching more trades.
> 
> **Overview**
> Increases the `FetchSlimTrades` request limit in `pingTradeStatus` from 3000 to 5000, allowing the alarm-driven trade status ping to process a larger set of pending trades per run.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa9d8f432888e7785ccea2b7d9d787ef3d61949f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->