### PR TITLE
Fixes Double Copy of WASM

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -95,6 +95,13 @@ module.exports = (env) => {
                         replacement: resolve('./src/environment.dev.ts'),
                     },
                 },
+                {
+                    test: /tlsn_wasm_bg\.wasm$/,
+                    type: 'asset/resource',
+                    generator: {
+                        filename: 'tlsn_wasm_bg.wasm',
+                    },
+                },
             ],
         },
         plugins: [
@@ -111,7 +118,7 @@ module.exports = (env) => {
                     {from: 'README.md', to: '', context: '.'},
                     {from: 'src/popup/popup.html', to: 'src/', context: '.'},
                     {from: 'src/offscreen/offscreen.html', to: 'src/', context: '.'},
-                    {from: 'node_modules/@csfloat/tlsn-wasm/*.{wasm,js}', to: '[name][ext]'},
+                    {from: 'node_modules/@csfloat/tlsn-wasm/*.js', to: '[name][ext]'},
                     {from: 'node_modules/@csfloat/tlsn-wasm/snippets', to: 'snippets/', context: '.'},
                     {
                         from: 'manifest.json',


### PR DESCRIPTION
TLSN Wasm is ~16MB, current setup was copying the file twice into the build.

This change switches to prevent a hash rename for `tlsn_wasm_bg.wasm` while still copying the `.js` files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only webpack configuration change scoped to how a single WASM asset is emitted and copied.
> 
> **Overview**
> Stops bundling/copying `@csfloat/tlsn-wasm`’s `tlsn_wasm_bg.wasm` twice by handling it via a dedicated webpack `asset/resource` rule that emits a stable `tlsn_wasm_bg.wasm` filename (no hashed rename).
> 
> Updates the `CopyPlugin` patterns to copy only the package’s `.js` files (and `snippets/`), removing the previous `*.{wasm,js}` copy step for the WASM binary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0da52d75e72a5d2040f67580729b19185736e3b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->