### PR TITLE
[Notary] Improves Estimate of Response Size when Content-Length Absent

### DIFF
--- a/src/offscreen/handlers/notary_prove.ts
+++ b/src/offscreen/handlers/notary_prove.ts
@@ -270,7 +270,7 @@ async function estimateGzipSize(data: Uint8Array): Promise<number> {
     const writer = cs.writable.getWriter();
     const reader = cs.readable.getReader();
 
-    writer.write(data as unknown as BufferSource);
+    writer.write(data as BufferSource);
     writer.close();
 
     let totalSize = 0;

--- a/src/offscreen/handlers/notary_prove.ts
+++ b/src/offscreen/handlers/notary_prove.ts
@@ -217,8 +217,10 @@ async function calculateResponseSize(
     if (perfBodySize > 0) {
         // encodedBodySize excludes chunked transfer encoding framing (chunk-size
         // hex digits + CRLFs per chunk), which IS counted by the notary. Pad to cover it.
-        console.debug('fallback to performance body size:', perfBodySize);
-        return headersSize + Math.ceil(perfBodySize * 1.05) + 256;
+        const adjustedPerfBodySize = Math.ceil(perfBodySize * 1.05) + 256;
+        console.debug('fallback to performance body size:', adjustedPerfBodySize);
+
+        return headersSize + adjustedPerfBodySize;
     }
 
     // Re-compress with gzip to approximate the on-wire body size.
@@ -228,8 +230,10 @@ async function calculateResponseSize(
         // CompressionStream uses zlib default (level 6), but the server may use a
         // lower level (larger output). Pad generously — overshooting is safe,
         // undershooting causes a protocol failure.
-        console.debug('fallback to estimated gzip size:', compressedSize);
-        return headersSize + Math.ceil(compressedSize * 1.20) + 256;
+        const adjustedCompressedSize = Math.ceil(compressedSize * 1.15) + 256;
+        console.debug('fallback to estimated gzip size:', adjustedCompressedSize);
+
+        return headersSize + adjustedCompressedSize;
     }
 
     // Last resort: decompressed body length (overshoots for compressed responses)

--- a/src/offscreen/handlers/notary_prove.ts
+++ b/src/offscreen/handlers/notary_prove.ts
@@ -161,9 +161,14 @@ function calculateRequestSize(
 }
 
 /**
- * Calculates the exact response byte size for the HTTP request by making the request itself and counting the response
+ * Calculates the response byte size for the HTTP request by making the request itself and counting the response.
  *
- * @param url Full request uRL including protocol, domain, path
+ * Fallback priority when content-length is absent (i.e., Transfer Encoding is chunked):
+ *  1. Resource Timing API (encodedBodySize) — on-wire size, but may be 0 for cross-origin without TAO
+ *  2. Re-compress with gzip via CompressionStream — close estimate when the response was gzip-encoded
+ *  3. Decompressed body length — last resort, will overshoot for compressed responses
+ *
+ * @param url Full request URL including protocol, domain, path
  * @param method HTTP method (ie. "GET")
  * @param headers HTTP request headers
  * @param body Optional request body
@@ -196,17 +201,82 @@ async function calculateResponseSize(
 
     const contentLength = response.headers.get('content-length');
 
-    let bodySize: number;
-
     if (contentLength) {
-        bodySize = parseInt(contentLength, 10);
-    } else {
-        console.debug('fallback to measuring response blob due to no content-length header');
-        const blob = await response.blob();
-        bodySize = blob.size;
+        return headersSize + parseInt(contentLength, 10);
     }
 
-    return headersSize + bodySize;
+    // No content-length; consume the body so we can estimate the on-wire size
+    const decompressedBody = await response.arrayBuffer();
+    const contentEncoding = response.headers.get('content-encoding');
+    const wasGzipped = contentEncoding?.toLowerCase().includes('gzip') ?? false;
+
+    // Try Resource Timing API for the encoded (on-wire) body size.
+    // Returns 0 for cross-origin responses without Timing-Allow-Origin,
+    // but worth checking since it's the most accurate when available.
+    const perfBodySize = await getEncodedBodySizeFromPerformance(url);
+    if (perfBodySize > 0) {
+        // encodedBodySize excludes chunked transfer encoding framing (chunk-size
+        // hex digits + CRLFs per chunk), which IS counted by the notary. Pad to cover it.
+        console.debug('fallback to performance body size:', perfBodySize);
+        return headersSize + Math.ceil(perfBodySize * 1.05) + 256;
+    }
+
+    // Re-compress with gzip to approximate the on-wire body size.
+    // Only meaningful when the server actually sent gzip'd data.
+    if (wasGzipped && typeof CompressionStream !== 'undefined') {
+        const compressedSize = await estimateGzipSize(new Uint8Array(decompressedBody));
+        // CompressionStream uses zlib default (level 6), but the server may use a
+        // lower level (larger output). Pad generously — overshooting is safe,
+        // undershooting causes a protocol failure.
+        console.debug('fallback to estimated gzip size:', compressedSize);
+        return headersSize + Math.ceil(compressedSize * 1.20) + 256;
+    }
+
+    // Last resort: decompressed body length (overshoots for compressed responses)
+    console.debug('fallback to decompressed body size — on-wire size may differ');
+    return headersSize + decompressedBody.byteLength;
+}
+
+/**
+ * Attempts to read the encoded (on-wire) body size from the Resource Timing API.
+ * Returns 0 if unavailable or if the entry reports 0 (e.g. cross-origin without TAO).
+ */
+async function getEncodedBodySizeFromPerformance(url: string): Promise<number> {
+    if (typeof performance === 'undefined' || !performance.getEntriesByName) {
+        return 0;
+    }
+
+    // Yield to the event loop so the browser has a chance to queue the entry
+    await new Promise<void>((r) => setTimeout(r, 0));
+
+    const entries = performance.getEntriesByName(url, 'resource') as PerformanceResourceTiming[];
+    if (entries.length === 0) {
+        return 0;
+    }
+
+    return entries[entries.length - 1].encodedBodySize ?? 0;
+}
+
+/**
+ * Compresses data with gzip using the Compression Streams API and returns the resulting size.
+ * Available in Chrome 80+ and Firefox 113+.
+ */
+async function estimateGzipSize(data: Uint8Array): Promise<number> {
+    const cs = new CompressionStream('gzip');
+    const writer = cs.writable.getWriter();
+    const reader = cs.readable.getReader();
+
+    writer.write(data as unknown as BufferSource);
+    writer.close();
+
+    let totalSize = 0;
+    while (true) {
+        const {done, value} = await reader.read();
+        if (done) break;
+        totalSize += value.byteLength;
+    }
+
+    return totalSize;
 }
 
 /**


### PR DESCRIPTION
Transfer encoding responses don't have a `Content-Length` header. Currently, we severely overshoot the body size since it counts the decompressed bytes.

Instead, this PR switches to more reliable methods such as the resource timing API and re-compressing with leeway.

Ref CSF-1322

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `max_recv_data` is estimated for chunked/gzipped responses; underestimation could cause notary/prover protocol failures, while overestimation mainly wastes headroom.
> 
> **Overview**
> Improves response size estimation in `calculateResponseSize` when `Content-Length` is missing by switching from `blob.size` (decompressed bytes) to a prioritized set of on-wire approximations.
> 
> When no `Content-Length` is present, it now consumes the body and estimates size via **Resource Timing `encodedBodySize` (with padding)**, then **re-gzipping via `CompressionStream` (with leeway)** when the response was gzip-encoded, and finally falls back to decompressed byte length; adds helper functions `getEncodedBodySizeFromPerformance` and `estimateGzipSize` and updates docs/debug logs accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfceef0c8993226d85002e8ff806e7c5792f4113. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->