### PR TITLE
Add Staging Extension To Steam Community Initiator Domains

### DIFF
--- a/src/steamcommunity_ruleset.json
+++ b/src/steamcommunity_ruleset.json
@@ -15,10 +15,7 @@
         "condition": {
             "urlFilter": "https://steamcommunity.com/tradeoffer/new/send",
             "resourceTypes": ["xmlhttprequest"],
-            "initiatorDomains": [
-                "jjicbefpemnphinccgikpdaagjebbnhg",
-                "gdlioplmcfbdloeoojolmlijihfplcmk"
-            ]
+            "initiatorDomains": ["jjicbefpemnphinccgikpdaagjebbnhg", "gdlioplmcfbdloeoojolmlijihfplcmk"]
         }
     }
 ]

--- a/src/steamcommunity_ruleset.json
+++ b/src/steamcommunity_ruleset.json
@@ -15,7 +15,10 @@
         "condition": {
             "urlFilter": "https://steamcommunity.com/tradeoffer/new/send",
             "resourceTypes": ["xmlhttprequest"],
-            "initiatorDomains": ["jjicbefpemnphinccgikpdaagjebbnhg"]
+            "initiatorDomains": [
+                "jjicbefpemnphinccgikpdaagjebbnhg",
+                "gdlioplmcfbdloeoojolmlijihfplcmk"
+            ]
         }
     }
 ]


### PR DESCRIPTION
ref CSF-1080

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single JSON configuration change that only broadens an allowlist of extension initiator IDs; minimal functional surface area.
> 
> **Overview**
> Updates `src/steamcommunity_ruleset.json` to **add a second allowed `initiatorDomains` entry**, enabling the existing `modifyHeaders` rule (setting `referer` for `https://steamcommunity.com/tradeoffer/new/send` XHRs) to apply when requests originate from the staging extension as well as the current one.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b1b8c84c125b2b110cb4934c1a404e96c050ac2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->