### PR TITLE
fix: Increase Strictness of Rollback Check

### DIFF
--- a/src/lib/alarms/rollback.ts
+++ b/src/lib/alarms/rollback.ts
@@ -30,7 +30,10 @@ function findRollbackTrades(pendingTrades: SlimTrade[], tradeHistory: TradeHisto
 
         // Does it correspond to an active CSFloat sale?
         const csfloatTrade = pendingTrades.find(
-            (e) => e.state === TradeState.PENDING && all_ids.includes(e.contract.item.asset_id)
+            (e) =>
+                e.state === TradeState.PENDING &&
+                all_ids.includes(e.contract.item.asset_id) &&
+                (trade.other_party_id === e.seller_id || trade.other_party_id === e.buyer_id)
         );
         if (!csfloatTrade) {
             continue;

--- a/src/lib/alarms/trade_history.ts
+++ b/src/lib/alarms/trade_history.ts
@@ -147,6 +147,7 @@ export async function getTradeHistoryFromAPI(
         .map((e) => {
             return {
                 other_party_url: `https://steamcommunity.com/profiles/${e.steamid_other}`,
+                other_party_id: e.steamid_other,
                 received_assets: (e.assets_received || [])
                     .filter((e) => e.appid === AppId.CSGO)
                     .map((e) => {
@@ -193,6 +194,7 @@ function parseTradeHistoryHTML(body: string): TradeHistoryStatus[] {
     const statuses = [...links].map((e) => {
         return {
             other_party_url: `https://steamcommunity.com/${e[1]}`,
+            other_party_id: '',
             received_assets: [],
             given_assets: [],
             trade_id: '',

--- a/src/lib/alarms/trade_offer.ts
+++ b/src/lib/alarms/trade_offer.ts
@@ -112,7 +112,8 @@ export async function pingCancelTrades(pendingTrades: SlimTrade[], tradeHistory:
             const rolledBackTrade = (tradeHistory || []).find(
                 (e) =>
                     e.status === TradeStatus.TradeProtectionRollback &&
-                    !!e.received_assets.find((a) => a.asset_id === trade.contract?.item?.asset_id)
+                    !!e.received_assets.find((a) => a.asset_id === trade.contract?.item?.asset_id) &&
+                    (e.other_party_id === trade.seller_id || e.other_party_id === trade.buyer_id)
             );
             if (!rolledBackTrade) {
                 // no rollback, trade offer was accepted, shouldn't cancel

--- a/src/lib/bridge/handlers/trade_history_status.ts
+++ b/src/lib/bridge/handlers/trade_history_status.ts
@@ -11,6 +11,7 @@ export interface TradeHistoryStatus {
     trade_id: string;
     status: number;
     other_party_url: string;
+    other_party_id: string;
     received_assets: TradeHistoryAsset[];
     given_assets: TradeHistoryAsset[];
     time_init: number;


### PR DESCRIPTION
Now that items don't receive a trade cooldown on reversal, their asset ID doesn't change either.

This change scopes the check to also ensure that the buyer/seller pair is aligned as well.

Ref CSF-1401

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how rollback and cancel pings are correlated to CSFloat trades; overly strict matching could miss legitimate rollbacks, while insufficient data (HTML-parsed history) may reduce detection in fallback paths.
> 
> **Overview**
> Improves rollback detection by scoping matches to both the traded `asset_id` **and** the expected buyer/seller counterparty, reducing false positives now that rollbacks may keep the same asset ID.
> 
> Adds `other_party_id` to `TradeHistoryStatus` (populated from the Steam API response) and uses it in `rollback.ts` and `trade_offer.ts` when correlating Steam trade-history rollbacks to pending CSFloat trades.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 855a7b2035324d458ca0591a067d5b5761c1ab28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->