### PR TITLE
Adds CSFloat price annotations to item holder in inventory/trade window.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -54,10 +54,7 @@
         "*://*.steamcommunity.com/market/listings/730/*",
         "*://*.steamcommunity.com/id/*/inventory*",
         "*://*.steamcommunity.com/id/*/tradehistory*",
-        "*://*.steamcommunity.com/profiles/*/inventory*",
-
-        "https://csfloat.com/*",
-        "https://gateway.floatdb.com/*"
+        "*://*.steamcommunity.com/profiles/*/inventory*"
     ],
     "optional_host_permissions": ["*://*.steampowered.com/*"],
     "externally_connectable": {

--- a/manifest.json
+++ b/manifest.json
@@ -54,7 +54,10 @@
         "*://*.steamcommunity.com/market/listings/730/*",
         "*://*.steamcommunity.com/id/*/inventory*",
         "*://*.steamcommunity.com/id/*/tradehistory*",
-        "*://*.steamcommunity.com/profiles/*/inventory*"
+        "*://*.steamcommunity.com/profiles/*/inventory*",
+
+        "https://csfloat.com/*",
+        "https://gateway.floatdb.com/*"
     ],
     "optional_host_permissions": ["*://*.steampowered.com/*"],
     "externally_connectable": {

--- a/src/lib/components/common/item_holder_metadata.ts
+++ b/src/lib/components/common/item_holder_metadata.ts
@@ -205,30 +205,28 @@ export abstract class ItemHolderMetadata extends FloatElement {
 
     async onInit() {
         if (!this.asset) return;
+        
+        if ((isSkin(this.asset) || isCharm(this.asset)) && this.inspectLink && this.assetId) {
+            try {
+                this.itemInfo = await gFloatFetcher.fetch({
+                    link: this.inspectLink,
+                    asset_id: this.assetId,
+                });
+            } catch (e: any) {
+                console.error(`Failed to fetch float for ${this.assetId}: ${e.toString()}`);
+            }
+        }
 
         if (isSellableOnCSFloat(this.asset)) {
             try {
                 const result = await ClientSend(FetchRecommendedPrice, {
                     market_hash_name: this.asset.market_hash_name,
+                    paint_index: this.itemInfo?.paintindex,
                 });
                 this.itemPrice = result.price;
             } catch (e: any) {
                 console.error(`Failed to fetch price for ${this.asset.market_hash_name}: ${e.toString()}`);
             }
-        }
-
-        if (!isSkin(this.asset) && !isCharm(this.asset)) return;
-
-        // Commodities won't have inspect links
-        if (!this.inspectLink || !this.assetId) return;
-
-        try {
-            this.itemInfo = await gFloatFetcher.fetch({
-                link: this.inspectLink,
-                asset_id: this.assetId,
-            });
-        } catch (e: any) {
-            console.error(`Failed to fetch float for ${this.assetId}: ${e.toString()}`);
         }
 
         if (this.itemInfo) {

--- a/src/lib/components/common/item_holder_metadata.ts
+++ b/src/lib/components/common/item_holder_metadata.ts
@@ -4,9 +4,12 @@ import {state} from 'lit/decorators.js';
 import {rgAsset} from '../../types/steam';
 import {gFloatFetcher} from '../../services/float_fetcher';
 import {ItemInfo} from '../../bridge/handlers/fetch_inspect_info';
+import {FetchRecommendedPrice} from '../../bridge/handlers/fetch_recommended_price';
 import {
+    isSellableOnCSFloat,
     formatFloatWithRank,
     formatSeed,
+    formatPrice,
     getFadePercentage,
     getLowestRank,
     isBlueSkin,
@@ -25,10 +28,21 @@ export abstract class ItemHolderMetadata extends FloatElement {
     static styles = [
         ...FloatElement.styles,
         css`
+            .price {
+                position: absolute;
+                bottom: 3px;
+                left: 3px;
+                right: 48px;
+                font-size: 12px;
+                text-align: left;
+                z-index: 2;
+            }
+
             .float {
                 position: absolute;
                 bottom: 3px;
                 right: 3px;
+                left: 50px;
                 font-size: 12px;
                 text-align: right;
             }
@@ -75,6 +89,9 @@ export abstract class ItemHolderMetadata extends FloatElement {
     @state()
     private bluegemData: FetchBluegemResponse | undefined;
 
+    @state()
+    private itemPrice: number | undefined;
+
     get assetId(): string | undefined {
         return $J(this).parent().attr('id')?.split('_')[2];
     }
@@ -85,6 +102,11 @@ export abstract class ItemHolderMetadata extends FloatElement {
 
     abstract get asset(): rgAsset | undefined;
     abstract get ownerSteamId(): string | undefined;
+
+    get isSellable(): boolean {
+        if (!this.asset) return false;
+        return isSellableOnCSFloat(this.asset);
+    }
 
     get inspectLink(): string | undefined {
         if (!this.asset) return;
@@ -105,7 +127,17 @@ export abstract class ItemHolderMetadata extends FloatElement {
     }
 
     protected render(): HTMLTemplateResult {
-        if (!this.itemInfo || !this.asset) return html``;
+        if (!this.asset) return html``;
+
+        if (!this.itemInfo) {
+            return html`
+            <span>
+                ${this.itemPrice
+                    ? html`<span class="price">$${formatPrice(this.itemPrice / 100)}</span>`
+                    : nothing}
+            </span>
+            `
+        }
 
         if (isSkin(this.asset)) {
             const fadeDetails = this.asset && getFadePercentage(this.asset, this.itemInfo);
@@ -118,7 +150,10 @@ export abstract class ItemHolderMetadata extends FloatElement {
 
             return html`
                 <span>
-                    <span class="float">${formatFloatWithRank(this.itemInfo, 6)}</span>
+                    <span class="float">${formatFloatWithRank(this.itemInfo, 3)}</span>
+                    ${this.itemPrice
+                        ? html`<span class="price">$${formatPrice(this.itemPrice / 100)}</span>`
+                        : nothing}
                     <span class="seed">
                         ${formatSeed(this.itemInfo)}
                         ${fadeDetails !== undefined
@@ -138,9 +173,10 @@ export abstract class ItemHolderMetadata extends FloatElement {
         } else if (isCharm(this.asset) && !isHighlightCharm(this.asset)) {
             return html`
                 <span>
-                    <span class="seed"
-                        >#${this.itemInfo.keychains?.length > 0 ? this.itemInfo.keychains[0].pattern : 'NA'}</span
-                    >
+                    ${this.itemPrice
+                        ? html`<span class="price">$${formatPrice(this.itemPrice / 100)}</span>`
+                        : nothing}
+                    <span class="seed">#${this.itemInfo.keychains?.length > 0 ? this.itemInfo.keychains[0].pattern : 'NA'}</span>
                 </span>
             `;
         } else {
@@ -151,14 +187,14 @@ export abstract class ItemHolderMetadata extends FloatElement {
     async connectedCallback() {
         super.connectedCallback();
 
-        if (this.inspectLink) {
+        if (this.isSellable) {
             this.onInit();
         } else {
             // Wait until the asset exists
             Observe(
-                () => this.inspectLink,
+                () => this.isSellable,
                 () => {
-                    if (this.inspectLink) {
+                    if (this.isSellable) {
                         this.onInit();
                     }
                 },
@@ -169,6 +205,17 @@ export abstract class ItemHolderMetadata extends FloatElement {
 
     async onInit() {
         if (!this.asset) return;
+
+        if (isSellableOnCSFloat(this.asset)) {
+            try {
+                const result = await ClientSend(FetchRecommendedPrice, {
+                    market_hash_name: this.asset.market_hash_name,
+                });
+                this.itemPrice = result.price;
+            } catch (e: any) {
+                console.error(`Failed to fetch price for ${this.asset.market_hash_name}: ${e.toString()}`);
+            }
+        }
 
         if (!isSkin(this.asset) && !isCharm(this.asset)) return;
 

--- a/src/lib/utils/skin.ts
+++ b/src/lib/utils/skin.ts
@@ -52,6 +52,16 @@ export function formatFloatWithRank(info: ItemInfo, precisionDigits = 14): strin
     return r;
 }
 
+export function formatPrice(price: number): string {
+
+    const formattedPrice =
+        price >= 100
+            ? Math.round(price).toString()
+            : Number(price.toFixed(2)).toString();
+
+    return formattedPrice;
+}
+
 export function formatSeed(info: ItemInfo): string {
     let r = info.paintseed.toString();
 

--- a/src/lib/utils/skin.ts
+++ b/src/lib/utils/skin.ts
@@ -41,8 +41,13 @@ export function parseRank(info: ItemInfo): {order: OrderType; rank: number} | un
     }
 }
 
+function truncate(num: number, digits: number): string {
+    const factor = 10 ** digits;
+    return (Math.trunc(num * factor) / factor).toFixed(digits);
+  }
+
 export function formatFloatWithRank(info: ItemInfo, precisionDigits = 14): string {
-    let r = info.floatvalue.toFixed(precisionDigits);
+    let r = truncate(info.floatvalue, precisionDigits);
 
     const ranked = parseRank(info);
     if (ranked) {
@@ -57,7 +62,7 @@ export function formatPrice(price: number): string {
     const formattedPrice =
         price >= 100
             ? Math.round(price).toString()
-            : Number(price.toFixed(2)).toString();
+            : Number(truncate(price, 2)).toString();
 
     return formattedPrice;
 }


### PR DESCRIPTION
- Adds CSFloat price overlays for sellable items (skins, agents, cases, stickers, charms, etc.)
- Displays prices wherever item holder metadata is rendered
- Reduces float precision from 6 to 3 decimals to improve spacing/readability

> Closes 2 in https://github.com/orgs/csfloat/projects/2/views/2?filterQuery=status%3ABacklog&pane=issue&itemId=88946730

### Inventory

<img width="318" height="319" alt="image" src="https://github.com/user-attachments/assets/b8f54aed-7ab6-49ae-9679-424fc2f52e00" />

### Trade Window

<img width="465" height="621" alt="image" src="https://github.com/user-attachments/assets/60c51848-7ca4-4566-91ec-d1d5d6358d4d" />
