### PR TITLE
Fix: Correct Response Handling in `ClientSend`

### DIFF
--- a/src/lib/bridge/client.ts
+++ b/src/lib/bridge/client.ts
@@ -29,10 +29,10 @@ export async function ClientSend<Req, Resp>(handler: RequestHandler<Req, Resp>, 
                 bundle,
                 // @ts-ignore Bad types
                 (resp: InternalResponseBundle) => {
-                    if (resp?.response) {
-                        resolve(resp.response);
+                    if (resp?.error) {
+                        reject(resp.error);
                     } else {
-                        reject(resp?.error);
+                        resolve(resp?.response);
                     }
                 }
             );

--- a/src/lib/bridge/client.ts
+++ b/src/lib/bridge/client.ts
@@ -27,7 +27,6 @@ export async function ClientSend<Req, Resp>(handler: RequestHandler<Req, Resp>, 
             runtimeNamespace().runtime.sendMessage(
                 window.CSFLOAT_EXTENSION_ID || chrome.runtime.id,
                 bundle,
-                // @ts-ignore Bad types
                 (resp: InternalResponseBundle) => {
                     if (resp?.error) {
                         reject(resp.error);


### PR DESCRIPTION
## Bug

Most of our enhanced pages currently print these errors: <img src="https://uploads.linear.app/b5470b6e-4a91-49eb-a603-cb4f6796d1e4/1e42f568-5538-46d0-9285-4829f601ca7f/22921f17-1f93-42a7-a46b-09110c5bdcdb?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiL2I1NDcwYjZlLTRhOTEtNDllYi1hNjAzLWNiNGY2Nzk2ZDFlNC8xZTQyZjU2OC01NTM4LTQ2ZDAtOTI4NS00ODI5ZjYwMWNhN2YvMjI5MjFmMTctMWY5My00MmE3LWE0NmItMDkxMTBjNWJkY2RiIiwiaWF0IjoxNzgxNTQ0MjEzLCJleHAiOjE4MTMxMTQ3NzN9.18x4KjUTwOsxUTgn6Kr4qwSPjjiRxXBShWOVNGKzrSk " alt="image" width="496" data-linear-height="60" />

`EmptyResponseHandler` returns `void` after successful execution, causing `ClientSend` to `reject` the promise.  <br>Addresses errors mentioned in csfloat/extension#402 as well

## Fix

Only reject on `error`, otherwise  `resolve` with `undefined`. Functionality unchanged, just gets rid of an incorrect rejection.

---

> < />!NOTE< />  <br>**Low Risk**  <br>Single-branch change in bridge client response handling; aligns with how the background already sends success vs error bundles.
>
> **Overview**  <br>Fixes incorrect promise rejection in `ClientSend` when talking to the background worker via `runtime.sendMessage`.
>
> The callback now **rejects only when** `resp.error` **is set** and **resolves with** `resp.response` **otherwise** (including `undefined`). Previously, a missing/falsy `response` was treated as failure, so handlers like `EmptyResponseHandler` that complete successfully with no payload caused spurious rejections and console errors on enhanced pages.
>
> Reviewed by [Cursor Bugbot](<https://cursor.com/bugbot>) for commit 712400b3ec19adf307042b9ed28bcb4d261340d5. Configure [here](<https://www.cursor.com/dashboard/bugbot>).