### PR TITLE
Add Repository Guard to GH Action Release Flows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   release:
+    if: github.repository == 'csfloat/extension'
     runs-on: "ubuntu-latest"
 
     strategy:

--- a/.github/workflows/submit_staging_chrome.yml
+++ b/.github/workflows/submit_staging_chrome.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   deploy-staging:
+    if: github.repository == 'csfloat/extension'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Small security change to prevent release and publishing jobs from running in repository forks.

Example (from the currently open community PR): https://github.com/rxl211/csfloat_extension/actions/runs/29103554597/job/86398255625 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only guard with no application code changes; reduces accidental or malicious workflow runs on forks.
> 
> **Overview**
> Adds a job-level **`if: github.repository == 'csfloat/extension'`** guard on the extension **release** workflow (tag pushes) and the **staging Chrome Web Store** deploy workflow (`master` / manual dispatch).
> 
> Forks that sync tags or branches will no longer run these jobs, so automated GitHub releases and Chrome staging uploads (including OAuth/CWS secret usage) stay limited to the canonical repository.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60964bbbeeee72c846a7b603ae6976b9df020638. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->