### PR TITLE
Update Handling of `Committed` Trades

### DIFF
--- a/src/lib/alarms/trade_history.ts
+++ b/src/lib/alarms/trade_history.ts
@@ -142,7 +142,12 @@ export async function getTradeHistoryFromAPI(
 
     const data = (await resp.json()) as TradeHistoryAPIResponse;
     return (data.response?.trades || [])
-        .filter((e) => e.status === TradeStatus.Complete || e.status === TradeStatus.TradeProtectionRollback) // Ensure we only count _complete_ trades (k_ETradeStatus_Complete) or rolled back (for reporting)
+        .filter(
+            (e) =>
+                e.status === TradeStatus.Committed ||
+                e.status === TradeStatus.Complete ||
+                e.status === TradeStatus.TradeProtectionRollback
+        ) // Only report exchanged/completed trades or trade-protection rollbacks
         .filter((e) => !e.time_escrow_end || new Date(parseInt(e.time_escrow_end) * 1000).getTime() < Date.now())
         .map((e) => {
             return {


### PR DESCRIPTION
Some trades can linger in the `Committed` state without ever reaching `Complete`. Since they are functionally equivalent, we need to report them server-side as well.

Ref CSF-1717

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which Steam trade statuses are forwarded for marketplace verification; mis-filtering could miss or over-report trades, but scope is limited to one filter in the alarms trade-history path.
> 
> **Overview**
> **Trade history reporting** now treats Steam trades in `Committed` status the same as completed ones when building history from `GetTradeHistory`.
> 
> `getTradeHistoryFromAPI` previously kept only `Complete` and `TradeProtectionRollback` entries. The filter also allows `TradeStatus.Committed`, so trades that never transition to `Complete` but are already exchanged still reach CSFloat verification via `pingTradeHistory`. Escrow and CS:GO asset mapping behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13db4d00f86bebfa1a92ebc6baf734e291bd4d88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->