### PR TITLE
fix(inventory): scale 3D modal with viewport, unify market action row

### DIFF
--- a/src/lib/components/common/skincraft_viewer_modal_styles.ts
+++ b/src/lib/components/common/skincraft_viewer_modal_styles.ts
@@ -7,8 +7,11 @@ export const skinCraftViewerModalStyles = `
         font-family: Arial, Helvetica, sans-serif;
     }
 
+    /* Width follows the viewport; the height-derived term caps the 16:9 stage at 80vh so the
+       composition scales with the screen, mirroring the market site's screenshot dialog. */
     dialog {
-        width: min(1120px, calc(100vw - 48px));
+        width: min(90vw, calc(80vh * 16 / 9));
+        width: min(90vw, calc(80dvh * 16 / 9));
         max-width: none;
         padding: 0;
         border: 1px solid rgba(193, 206, 255, 0.12);
@@ -429,8 +432,10 @@ export const skinCraftViewerModalStyles = `
     }
 
     @media (min-width: 1168px) and (max-width: 1519px) and (min-height: 840px) {
+        /* The 122px item strip sits above the stage, so it joins the height budget. */
         dialog.has-items {
-            width: 1120px;
+            width: max(1120px, min(90vw, calc((80vh - 122px) * 16 / 9)));
+            width: max(1120px, min(90vw, calc((80dvh - 122px) * 16 / 9)));
         }
 
         dialog.has-items .modal-body {
@@ -463,19 +468,24 @@ export const skinCraftViewerModalStyles = `
     }
 
     @media (min-width: 1520px) {
+        /* The 320px item panel sits beside the stage, so it joins the width budget instead. */
         dialog.has-items {
-            width: min(1440px, calc(100vw - 48px));
+            width: min(90vw, calc(80vh * 16 / 9 + 320px));
+            width: min(90vw, calc(80dvh * 16 / 9 + 320px));
         }
 
         dialog.has-items .modal-body {
             display: grid;
-            grid-template-columns: minmax(280px, 320px) 1120px;
+            grid-template-columns: 320px minmax(0, 1fr);
         }
 
         dialog.has-items .item-panel {
             display: flex;
             flex-direction: column;
-            height: min(630px, calc(100vh - 104px));
+            /* The stage's height (its column width at 16:9), restated because the panel's own
+               content must not be what sizes the shared grid row. */
+            height: min(calc((90vw - 320px) * 9 / 16), 80vh);
+            height: min(calc((90vw - 320px) * 9 / 16), 80dvh);
             border-right: 1px solid rgba(193, 206, 255, 0.1);
         }
 
@@ -498,10 +508,6 @@ export const skinCraftViewerModalStyles = `
 
         dialog.has-items .item-card {
             height: 92px;
-        }
-
-        dialog.has-items .viewer-stage {
-            width: 1120px;
         }
     }
 

--- a/src/lib/components/common/skincraft_viewer_modal_styles.ts
+++ b/src/lib/components/common/skincraft_viewer_modal_styles.ts
@@ -8,10 +8,11 @@ export const skinCraftViewerModalStyles = `
     }
 
     /* Width follows the viewport; the height-derived term caps the 16:9 stage at 80vh so the
-       composition scales with the screen, mirroring the market site's screenshot dialog. */
+       composition scales with the screen. The 1920px ceiling is the stage's native resolution —
+       past it 4K+ displays only upscale. */
     dialog {
-        width: min(90vw, calc(80vh * 16 / 9));
-        width: min(90vw, calc(80dvh * 16 / 9));
+        width: min(90vw, calc(80vh * 16 / 9), 1920px);
+        width: min(90vw, calc(80dvh * 16 / 9), 1920px);
         max-width: none;
         padding: 0;
         border: 1px solid rgba(193, 206, 255, 0.12);
@@ -470,8 +471,8 @@ export const skinCraftViewerModalStyles = `
     @media (min-width: 1520px) {
         /* The 320px item panel sits beside the stage, so it joins the width budget instead. */
         dialog.has-items {
-            width: min(90vw, calc(80vh * 16 / 9 + 320px));
-            width: min(90vw, calc(80dvh * 16 / 9 + 320px));
+            width: min(90vw, calc(80vh * 16 / 9 + 320px), 2240px);
+            width: min(90vw, calc(80dvh * 16 / 9 + 320px), 2240px);
         }
 
         dialog.has-items .modal-body {
@@ -483,9 +484,10 @@ export const skinCraftViewerModalStyles = `
             display: flex;
             flex-direction: column;
             /* The stage's height (its column width at 16:9), restated because the panel's own
-               content must not be what sizes the shared grid row. */
-            height: min(calc((90vw - 320px) * 9 / 16), 80vh);
-            height: min(calc((90vw - 320px) * 9 / 16), 80dvh);
+               content must not be what sizes the shared grid row. Tracks the same 2240px ceiling
+               as the dialog, or it would outgrow the stage it sits beside. */
+            height: min(calc((min(90vw, 2240px) - 320px) * 9 / 16), 80vh);
+            height: min(calc((min(90vw, 2240px) - 320px) * 9 / 16), 80dvh);
             border-right: 1px solid rgba(193, 206, 255, 0.1);
         }
 

--- a/src/lib/components/inventory/selected_item_info.ts
+++ b/src/lib/components/inventory/selected_item_info.ts
@@ -60,10 +60,10 @@ export class SelectedItemInfo extends FloatElement {
                 flex-wrap: wrap;
                 align-items: center;
                 gap: 10px;
+                margin: 14px 0 10px;
             }
 
             .market-btn-container {
-                margin: 10px 0 10px 0;
                 padding: 5px;
                 width: fit-content;
                 border: solid 1px rgb(56 64 77);
@@ -219,17 +219,17 @@ export class SelectedItemInfo extends FloatElement {
             );
         }
 
-        if (this.canListOnCSFloat || this.show3dButton) {
-            // The modal lives outside the flex row: as a flex item its host would add a gap and
-            // nudge the 3D button whenever it mounts.
+        if (this.canListOnCSFloat || this.show3dButton || this.stallListing) {
+            // One flex row for every action: the market action (list button or active listing —
+            // mutually exclusive) keeps the left slot in both states, and nothing wraps while
+            // there's room. The modal lives outside the row: as a flex item its host would add a
+            // gap and nudge the 3D button whenever it mounts.
             containerChildren.push(
-                html`<div class="market-btn-row">${this.renderListOnCSFloat()} ${this.renderViewIn3D()}</div>
+                html`<div class="market-btn-row">
+                        ${this.renderListOnCSFloat()} ${this.renderFloatMarketListing()} ${this.renderViewIn3D()}
+                    </div>
                     ${this.renderListModal()}`
             );
-        }
-
-        if (isSellableOnCSFloat(this.asset.description)) {
-            containerChildren.push(this.renderFloatMarketListing());
         }
 
         if (containerChildren.length === 0) {


### PR DESCRIPTION
Follow-up to #410, addressing @Step7750's review comments.

**Modal size** — the dialog now scales with the viewport instead of pinning to 1120px, using the same treatment as the market site's screenshot dialog: width follows 90vw, with a height-derived cap that keeps the 16:9 stage at or under 80vh. The side-panel layout (≥1520px) adds its 320px panel to the width budget; the item-strip layout (1168–1519px) adds its 122px strip to the height budget, with a 1120px floor so mid-size screens keep today's size. On a 1440p display the viewer stage grows from 1120×630 to ~1984×1116.

**Action row** — the CSFloat market action (list button or active listing, mutually exclusive) and the 3D button now share one flex row: the market action keeps the left slot whether the item is listed or not, and the buttons no longer wrap to new lines when there's room. Also adds a bit more gap between the float/paint seed info and the row.

## Validation

`npm run lint`, `npm run build`, `npm run checkformat`, `npm test` (31/31).

<img width="1800" height="1033" alt="3d-modal-scaled" src="https://github.com/user-attachments/assets/ddd1c466-ac64-42af-a832-54e7602b4c44" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS layout and inventory UI composition only; no auth, API, or data-path changes.
> 
> **Overview**
> The SkinCraft 3D viewer dialog **scales with the viewport** instead of staying near a fixed 1120px width: default sizing uses `90vw` and a **16:9 cap at 80vh** (with `dvh` fallbacks and a 1920px stage ceiling). Breakpoints for the item strip and side panel **fold those chrome dimensions into the width/height budget**, use a **1120px floor** on mid-width layouts, and drop the hard-coded stage width so the grid can grow with the dialog.
> 
> In **selected item info**, the CSFloat **list**, **active listing**, and **View in 3D** actions share **one flex row** (listing is no longer rendered below), with `stallListing` included in when that row appears so listed-only items still show the row. Spacing above the action row is slightly increased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65e35c4e1b80e91a569b4bee3a87b6b4e0a93e89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->