### PR TITLE
feat(inventory): open the 3d embed to sticker, patch, charm, and agent items

### DIFF
--- a/src/environment.dev.ts
+++ b/src/environment.dev.ts
@@ -7,5 +7,5 @@ export const environment = {
     },
     reverse_watch_base_api_url: 'http://localhost:3434/api',
     floatdb_gateway_url: 'https://gateway.floatdb.com',
-    skincraft_embed_origin: 'https://localhost:3000',
+    skincraft_embed_origin: 'https://beta.skincraft.gg',
 };

--- a/src/lib/services/skincraft_embed.ts
+++ b/src/lib/services/skincraft_embed.ts
@@ -217,10 +217,16 @@ class SkinCraftEmbedService {
                 this.modal?.setError(message.message || 'SkinCraft could not load this item.');
                 break;
             case 'inspect-requested': {
-                // Re-check the shape: targets on the direct open() path never cross the
-                // validated page boundary.
+                // Re-checked at the navigation sink. `loaded` means the frame shows `activeTarget` — a
+                // switch-in-place keeps the old model on screen while the next loads, and it must not launch.
+                if (!this.active) break;
+
                 const url = this.activeTarget?.inspectUrl;
-                if (this.active && url && STEAM_INSPECT_URL_PATTERN.test(url)) window.location.href = url;
+                if (this.loadPhase === 'loaded' && url && STEAM_INSPECT_URL_PATTERN.test(url)) {
+                    window.location.href = url;
+                } else {
+                    console.warn('SkinCraft: no launchable inspect link for the item on screen.');
+                }
                 break;
             }
         }

--- a/src/lib/services/skincraft_embed.ts
+++ b/src/lib/services/skincraft_embed.ts
@@ -9,7 +9,11 @@ import {
 } from './skincraft_embed_protocol';
 import type {SkinCraftEmbedCommand} from './skincraft_embed_protocol';
 import {getLoadedInventoryTargets} from './skincraft_inventory_targets';
-import {isOpenSkinCraftViewerMessage, SKINCRAFT_VIEWER_MESSAGE_SOURCE} from './skincraft_viewer_protocol';
+import {
+    isOpenSkinCraftViewerMessage,
+    SKINCRAFT_VIEWER_MESSAGE_SOURCE,
+    STEAM_INSPECT_URL_PATTERN,
+} from './skincraft_viewer_protocol';
 import type {OpenSkinCraftViewerMessage, SkinCraftItem, SkinCraftViewerTarget} from './skincraft_viewer_protocol';
 
 const LOAD_TIMEOUT_MS = 20_000;
@@ -212,6 +216,13 @@ class SkinCraftEmbedService {
                 this.frameHasContent = false;
                 this.modal?.setError(message.message || 'SkinCraft could not load this item.');
                 break;
+            case 'inspect-requested': {
+                // Re-check the shape: targets on the direct open() path never cross the
+                // validated page boundary.
+                const url = this.activeTarget?.inspectUrl;
+                if (this.active && url && STEAM_INSPECT_URL_PATTERN.test(url)) window.location.href = url;
+                break;
+            }
         }
     };
 

--- a/src/lib/services/skincraft_embed.ts
+++ b/src/lib/services/skincraft_embed.ts
@@ -217,8 +217,8 @@ class SkinCraftEmbedService {
                 this.modal?.setError(message.message || 'SkinCraft could not load this item.');
                 break;
             case 'inspect-requested': {
-                // Re-checked at the navigation sink. `loaded` means the frame shows `activeTarget` — a
-                // switch-in-place keeps the old model on screen while the next loads, and it must not launch.
+                // A switch-in-place keeps the old model on screen while the next loads; only `loaded`
+                // means the frame shows `activeTarget`.
                 if (!this.active) break;
 
                 const url = this.activeTarget?.inspectUrl;

--- a/src/lib/services/skincraft_embed_protocol.test.ts
+++ b/src/lib/services/skincraft_embed_protocol.test.ts
@@ -11,6 +11,7 @@ describe('SkinCraft embed messages', () => {
         expect(
             isSkinCraftEmbedEvent({...envelope, type: 'error', id: '1', code: 'load-failed', message: 'Failed'})
         ).toBe(true);
+        expect(isSkinCraftEmbedEvent({...envelope, type: 'inspect-requested'})).toBe(true);
     });
 
     it('rejects spoofed, malformed, and unknown messages', () => {

--- a/src/lib/services/skincraft_embed_protocol.ts
+++ b/src/lib/services/skincraft_embed_protocol.ts
@@ -18,6 +18,9 @@ export type SkinCraftEmbedEvent = EmbedEnvelope &
         | {type: 'progress'; id?: string; percent: number | null; label?: string}
         | {type: 'loaded'; id?: string}
         | {type: 'error'; id?: string; code: string; message: string}
+        // Inspect click forwarded out of the sandboxed iframe (it can't launch
+        // steam:// itself); we launch the shown item's own inspect link.
+        | {type: 'inspect-requested'}
     );
 
 export function isSkinCraftEmbedEvent(data: unknown): data is SkinCraftEmbedEvent {
@@ -35,6 +38,7 @@ export function isSkinCraftEmbedEvent(data: unknown): data is SkinCraftEmbedEven
     const hasValidId = message.id === undefined || typeof message.id === 'string';
     switch (message.type) {
         case 'ready':
+        case 'inspect-requested':
             return true;
         case 'progress':
             return hasValidId && (message.label === undefined || typeof message.label === 'string');

--- a/src/lib/services/skincraft_embed_protocol.ts
+++ b/src/lib/services/skincraft_embed_protocol.ts
@@ -18,8 +18,7 @@ export type SkinCraftEmbedEvent = EmbedEnvelope &
         | {type: 'progress'; id?: string; percent: number | null; label?: string}
         | {type: 'loaded'; id?: string}
         | {type: 'error'; id?: string; code: string; message: string}
-        // Inspect click forwarded out of the sandboxed iframe (it can't launch
-        // steam:// itself); we launch the shown item's own inspect link.
+        // The sandboxed iframe can't launch steam:// itself.
         | {type: 'inspect-requested'}
     );
 

--- a/src/lib/services/skincraft_inventory_targets.test.ts
+++ b/src/lib/services/skincraft_inventory_targets.test.ts
@@ -72,20 +72,34 @@ describe('SkinCraft inventory targets', () => {
                 tags: [{category: 'Weapon', internal_name: 'weapon_ak47'}],
                 actions: [
                     {name: 'View Wiki', link: 'https://example.com/wiki'},
-                    {
-                        name: 'Inspect in Game...',
-                        link: 'steam://rungame/730/76561202255233023/+csgo_econ_action_preview%20%propid:6%',
-                    },
+                    {name: 'Inspect in Game...', link: 'steam://run/730//+csgo_econ_action_preview%20%propid:6%'},
                 ],
             },
         } as unknown as InventoryAsset;
 
         expect(toSkinCraftItem(asset)?.inspectUrl).toBe(
-            `steam://rungame/730/76561202255233023/+csgo_econ_action_preview%20${'a'.repeat(80)}`
+            `steam://run/730//+csgo_econ_action_preview%20${'a'.repeat(80)}`
         );
     });
 
-    it('omits the launch link when no action carries the masked placeholder', () => {
+    it('extracts the inspect from action links that embed the hex directly', () => {
+        const hex = 'A'.repeat(54);
+        const asset = {
+            assetid: '123',
+            description: {
+                market_hash_name: 'Sticker | Crown (Foil)',
+                type: 'High Grade Sticker',
+                tags: [{category: 'Type', internal_name: 'CSGO_Tool_Sticker'}],
+                actions: [{name: 'Inspect in Game...', link: `steam://run/730//+csgo_econ_action_preview%20${hex}`}],
+            },
+        } as unknown as InventoryAsset;
+        const target = toSkinCraftItem(asset);
+
+        expect(target?.inspect).toBe(hex);
+        expect(target?.inspectUrl).toBe(`steam://run/730//+csgo_econ_action_preview%20${hex}`);
+    });
+
+    it('omits the launch link when no action is a masked inspect launch', () => {
         const asset = {
             assetid: '123',
             asset_properties: [{propertyid: 6, string_value: 'a'.repeat(80)}],

--- a/src/lib/services/skincraft_inventory_targets.test.ts
+++ b/src/lib/services/skincraft_inventory_targets.test.ts
@@ -3,6 +3,7 @@ import type {ItemInfo} from '../bridge/handlers/fetch_inspect_info';
 import type {CAppwideInventory, CInventory, InventoryAsset} from '../types/steam';
 import {ContextId} from '../types/steam_constants';
 import {getLoadedInventoryTargets, toSkinCraftItem} from './skincraft_inventory_targets';
+import {isOpenSkinCraftViewerMessage, SKINCRAFT_VIEWER_MESSAGE_SOURCE} from './skincraft_viewer_protocol';
 
 function createInventory(assets: InventoryAsset[]): CInventory {
     return {
@@ -27,6 +28,119 @@ describe('SkinCraft inventory targets', () => {
         } as unknown as InventoryAsset;
 
         expect(toSkinCraftItem(asset)?.inspect).toBe('a'.repeat(80));
+    });
+
+    it.each([
+        ['sticker', 'High Grade Sticker', 'CSGO_Tool_Sticker'],
+        ['patch', 'High Grade Patch', 'CSGO_Type_Patch'],
+        ['charm', 'Extraordinary Charm', 'CSGO_Tool_Keychain'],
+        ['agent', 'Master Agent', 'Type_CustomPlayer'],
+    ])('accepts %s items with inspect data', (_kind, type, internalName) => {
+        const asset = {
+            assetid: '123',
+            asset_properties: [{propertyid: 6, string_value: 'a'.repeat(80)}],
+            description: {
+                market_hash_name: 'name',
+                type,
+                tags: [{category: 'Type', internal_name: internalName}],
+            },
+        } as unknown as InventoryAsset;
+
+        expect(toSkinCraftItem(asset)?.inspect).toBe('a'.repeat(80));
+    });
+
+    it('rejects item types SkinCraft cannot render', () => {
+        const asset = {
+            assetid: '123',
+            asset_properties: [{propertyid: 6, string_value: 'a'.repeat(80)}],
+            description: {
+                market_hash_name: 'Dreams & Nightmares Case',
+                type: 'Base Grade Container',
+                tags: [{category: 'Type', internal_name: 'CSGO_Type_WeaponCase'}],
+            },
+        } as unknown as InventoryAsset;
+
+        expect(toSkinCraftItem(asset)).toBeUndefined();
+    });
+
+    it('derives the steam launch link from the masked inspect action, wherever it sits', () => {
+        const asset = {
+            assetid: '123',
+            asset_properties: [{propertyid: 6, string_value: 'a'.repeat(80)}],
+            description: {
+                market_hash_name: 'AK-47 | Redline (Field-Tested)',
+                tags: [{category: 'Weapon', internal_name: 'weapon_ak47'}],
+                actions: [
+                    {name: 'View Wiki', link: 'https://example.com/wiki'},
+                    {
+                        name: 'Inspect in Game...',
+                        link: 'steam://rungame/730/76561202255233023/+csgo_econ_action_preview%20%propid:6%',
+                    },
+                ],
+            },
+        } as unknown as InventoryAsset;
+
+        expect(toSkinCraftItem(asset)?.inspectUrl).toBe(
+            `steam://rungame/730/76561202255233023/+csgo_econ_action_preview%20${'a'.repeat(80)}`
+        );
+    });
+
+    it('omits the launch link when no action carries the masked placeholder', () => {
+        const asset = {
+            assetid: '123',
+            asset_properties: [{propertyid: 6, string_value: 'a'.repeat(80)}],
+            description: {
+                market_hash_name: 'AK-47 | Redline (Field-Tested)',
+                tags: [{category: 'Weapon', internal_name: 'weapon_ak47'}],
+                actions: [
+                    {name: 'View Wiki', link: 'https://example.com/wiki'},
+                    {name: 'Inspect in Game...', link: 'steam://rungame/730/123/+csgo_econ_action_preview%20S1A2D3'},
+                ],
+            },
+        } as unknown as InventoryAsset;
+
+        expect(toSkinCraftItem(asset)?.inspectUrl).toBeUndefined();
+    });
+
+    it('produces items the viewer protocol accepts, even for oversized inspects', () => {
+        const asset = {
+            assetid: '123',
+            asset_properties: [{propertyid: 6, string_value: 'a'.repeat(5000)}],
+            description: {
+                market_hash_name: 'AK-47 | Redline (Field-Tested)',
+                tags: [{category: 'Weapon', internal_name: 'weapon_ak47'}],
+                actions: [
+                    {
+                        name: 'Inspect in Game...',
+                        link: 'steam://rungame/730/76561202255233023/+csgo_econ_action_preview%20%propid:6%',
+                    },
+                ],
+            },
+        } as unknown as InventoryAsset;
+        const target = toSkinCraftItem(asset);
+
+        expect(target?.inspectUrl).toBeDefined();
+        expect(
+            isOpenSkinCraftViewerMessage({
+                source: SKINCRAFT_VIEWER_MESSAGE_SOURCE,
+                type: 'open',
+                target,
+                inventory: [target],
+            })
+        ).toBe(true);
+    });
+
+    it('rejects half-hydrated non-skin descriptions without throwing', () => {
+        const asset = {
+            assetid: '123',
+            asset_properties: [{propertyid: 6, string_value: 'a'.repeat(80)}],
+            description: {
+                market_hash_name: 'name',
+                tags: [{category: 'Type', internal_name: 'CSGO_Tool_Sticker'}],
+            },
+        } as unknown as InventoryAsset;
+
+        expect(toSkinCraftItem(asset)).toBeUndefined();
     });
 
     it('skips Steam assets whose descriptions are not initialized yet', () => {

--- a/src/lib/services/skincraft_inventory_targets.test.ts
+++ b/src/lib/services/skincraft_inventory_targets.test.ts
@@ -33,7 +33,8 @@ describe('SkinCraft inventory targets', () => {
     it.each([
         ['sticker', 'High Grade Sticker', 'CSGO_Tool_Sticker'],
         ['patch', 'High Grade Patch', 'CSGO_Type_Patch'],
-        ['charm', 'Extraordinary Charm', 'CSGO_Tool_Keychain'],
+        // Localized `type`, so this row lands on the tag branch the way non-English Steam does.
+        ['charm', 'Breloque extraordinaire', 'CSGO_Tool_Keychain'],
         ['agent', 'Master Agent', 'Type_CustomPlayer'],
     ])('accepts %s items with inspect data', (_kind, type, internalName) => {
         const asset = {
@@ -113,10 +114,49 @@ describe('SkinCraft inventory targets', () => {
             },
         } as unknown as InventoryAsset;
 
+        expect(toSkinCraftItem(asset)).toEqual(
+            expect.objectContaining({inspect: 'a'.repeat(80), inspectUrl: undefined})
+        );
+    });
+
+    it('ignores inspect-shaped actions that are not steam launch links', () => {
+        const hex = 'a'.repeat(80);
+        const asset = {
+            assetid: '123',
+            asset_properties: [{propertyid: 6, string_value: hex}],
+            description: {
+                market_hash_name: 'AK-47 | Redline (Field-Tested)',
+                tags: [{category: 'Weapon', internal_name: 'weapon_ak47'}],
+                actions: [
+                    {name: 'Inspect in Game...', link: `https://example.com/#+csgo_econ_action_preview%20${hex}`},
+                ],
+            },
+        } as unknown as InventoryAsset;
+
         expect(toSkinCraftItem(asset)?.inspectUrl).toBeUndefined();
     });
 
-    it('produces items the viewer protocol accepts, even for oversized inspects', () => {
+    it('builds the launch link around the rendered hex, not the one embedded in the link', () => {
+        const property = 'a'.repeat(80);
+        const embedded = 'b'.repeat(80);
+        const asset = {
+            assetid: '123',
+            asset_properties: [{propertyid: 6, string_value: property}],
+            description: {
+                market_hash_name: 'AK-47 | Redline (Field-Tested)',
+                tags: [{category: 'Weapon', internal_name: 'weapon_ak47'}],
+                actions: [
+                    {name: 'Inspect in Game...', link: `steam://run/730//+csgo_econ_action_preview%20${embedded}`},
+                ],
+            },
+        } as unknown as InventoryAsset;
+        const target = toSkinCraftItem(asset);
+
+        expect(target?.inspect).toBe(property);
+        expect(target?.inspectUrl).toBe(`steam://run/730//+csgo_econ_action_preview%20${property}`);
+    });
+
+    it('produces items the viewer protocol accepts, including very long inspects', () => {
         const asset = {
             assetid: '123',
             asset_properties: [{propertyid: 6, string_value: 'a'.repeat(5000)}],
@@ -144,7 +184,7 @@ describe('SkinCraft inventory targets', () => {
         ).toBe(true);
     });
 
-    it('rejects half-hydrated non-skin descriptions without throwing', () => {
+    it('identifies half-hydrated descriptions by tag, without throwing on the missing type', () => {
         const asset = {
             assetid: '123',
             asset_properties: [{propertyid: 6, string_value: 'a'.repeat(80)}],
@@ -154,7 +194,7 @@ describe('SkinCraft inventory targets', () => {
             },
         } as unknown as InventoryAsset;
 
-        expect(toSkinCraftItem(asset)).toBeUndefined();
+        expect(toSkinCraftItem(asset)?.inspect).toBe('a'.repeat(80));
     });
 
     it('skips Steam assets whose descriptions are not initialized yet', () => {

--- a/src/lib/services/skincraft_inventory_targets.ts
+++ b/src/lib/services/skincraft_inventory_targets.ts
@@ -38,8 +38,7 @@ const PROPERTY_SLOT = '%propid:6%';
 const MASKED_ACTION_PATTERN =
     /^steam:\/\/(?:run|rungame)\/730\/\d{0,20}\/\+csgo_econ_action_preview%20(%propid:6%|[0-9a-f]{40,8192})$/i;
 
-/** The description's masked inspect action, split at the hex slot. Steam either leaves a
- *  `%propid:6%` slot to fill from asset property 6, or embeds the hex in the link itself. */
+/** Split at the hex slot, which Steam either fills from asset property 6 or embeds inline. */
 function getMaskedInspectAction(description: rgAsset): {prefix: string; embeddedHex?: string} | undefined {
     for (const action of description.actions ?? []) {
         const slot = MASKED_ACTION_PATTERN.exec(action.link)?.[1];
@@ -53,7 +52,6 @@ function getMaskedInspectAction(description: rgAsset): {prefix: string; embedded
     return undefined;
 }
 
-/** The item's masked inspect hex, plus the `steam://` link that launches that same hex. */
 function getSkinCraftInspect(
     asset: InventoryAsset,
     fallbackProperties: rgAssetProperty[]

--- a/src/lib/services/skincraft_inventory_targets.ts
+++ b/src/lib/services/skincraft_inventory_targets.ts
@@ -23,44 +23,52 @@ function getAssetProperties(asset: InventoryAsset, fallbackProperties: rgAssetPr
     return fallbackProperties;
 }
 
-/** Item types SkinCraft renders (weapons and gloves are both matched by `isSkin`). */
+/** Item types SkinCraft renders (gloves fall under `isSkin`). */
 function isSkinCraftRenderable(description: rgAsset): boolean {
-    if (isSkin(description)) return true;
-    // Half-hydrated descriptions may lack `type`, which the predicates below dereference.
-    if (typeof description.type !== 'string') return false;
-    return isSticker(description) || isCharm(description) || isPatch(description) || isAgent(description);
+    return (
+        isSkin(description) ||
+        isSticker(description) ||
+        isCharm(description) ||
+        isPatch(description) ||
+        isAgent(description)
+    );
 }
 
-const MASKED_ACTION_PATTERN = /\+csgo_econ_action_preview%20(%propid:6%|[0-9a-f]{40,8192})$/i;
+const PROPERTY_SLOT = '%propid:6%';
+const MASKED_ACTION_PATTERN =
+    /^steam:\/\/(?:run|rungame)\/730\/\d{0,20}\/\+csgo_econ_action_preview%20(%propid:6%|[0-9a-f]{40,8192})$/i;
 
-/** The description's masked inspect action. Steam ships the hex two ways: as asset
- *  property 6 with a `%propid:6%` slot in the link (skins), or embedded directly in
- *  the link (stickers). */
-function getMaskedInspectAction(description: rgAsset): {link: string; embeddedHex?: string} | undefined {
+/** The description's masked inspect action, split at the hex slot. Steam either leaves a
+ *  `%propid:6%` slot to fill from asset property 6, or embeds the hex in the link itself. */
+function getMaskedInspectAction(description: rgAsset): {prefix: string; embeddedHex?: string} | undefined {
     for (const action of description.actions ?? []) {
-        const hex = MASKED_ACTION_PATTERN.exec(action.link)?.[1];
-        if (hex) return {link: action.link, embeddedHex: hex === '%propid:6%' ? undefined : hex};
+        const slot = MASKED_ACTION_PATTERN.exec(action.link)?.[1];
+        if (slot) {
+            return {
+                prefix: action.link.slice(0, action.link.length - slot.length),
+                embeddedHex: slot.toLowerCase() === PROPERTY_SLOT ? undefined : slot,
+            };
+        }
     }
     return undefined;
 }
 
+/** The item's masked inspect hex, plus the `steam://` link that launches that same hex. */
 function getSkinCraftInspect(
-    asset: InventoryAsset | undefined,
+    asset: InventoryAsset,
     fallbackProperties: rgAssetProperty[]
-): string | undefined {
-    if (!asset?.description || !isSkinCraftRenderable(asset.description)) return;
+): Pick<SkinCraftItem, 'inspect' | 'inspectUrl'> | undefined {
+    if (!isSkinCraftRenderable(asset.description)) return;
 
-    const property = getAssetProperties(asset, fallbackProperties)
-        .find((property) => property.propertyid === 6)
-        ?.string_value?.trim();
-    return property || getMaskedInspectAction(asset.description)?.embeddedHex;
-}
-
-/** The asset's `steam://` inspect launch link, with any `%propid:6%` slot filled with the masked hex. */
-function getSteamInspectUrl(asset: InventoryAsset, inspect: string): string | undefined {
     const action = getMaskedInspectAction(asset.description);
-    const url = action?.embeddedHex ? action.link : action?.link.replace('%propid:6%', inspect);
-    return url && STEAM_INSPECT_URL_PATTERN.test(url) ? url : undefined;
+    const inspect =
+        getAssetProperties(asset, fallbackProperties)
+            .find((property) => property.propertyid === 6)
+            ?.string_value?.trim() || action?.embeddedHex;
+    if (!inspect || !SKINCRAFT_INSPECT_PATTERN.test(inspect)) return;
+
+    const inspectUrl = action && `${action.prefix}${inspect}`;
+    return {inspect, inspectUrl: inspectUrl && STEAM_INSPECT_URL_PATTERN.test(inspectUrl) ? inspectUrl : undefined};
 }
 
 export function toSkinCraftItem(
@@ -70,16 +78,15 @@ export function toSkinCraftItem(
 ): SkinCraftItem | undefined {
     if (!asset?.description || typeof asset.description.market_hash_name !== 'string') return;
 
-    const inspect = getSkinCraftInspect(asset, fallbackProperties);
-    if (!inspect || !SKINCRAFT_INSPECT_PATTERN.test(inspect)) return;
+    const inspectFields = getSkinCraftInspect(asset, fallbackProperties);
+    if (!inspectFields) return;
 
     const icon = asset.description.icon_url_large || asset.description.icon_url;
     const itemInfo = getCachedItemInfo(asset.assetid);
     const rarityColor = asset.description.tags?.find((tag) => tag.category === 'Rarity')?.color;
     const backgroundColor = asset.description.background_color;
     return {
-        inspect,
-        inspectUrl: getSteamInspectUrl(asset, inspect),
+        ...inspectFields,
         name: asset.description.market_hash_name,
         iconUrl: icon ? steamEconomyImageUrl(icon) : undefined,
         assetId: asset.assetid,

--- a/src/lib/services/skincraft_inventory_targets.ts
+++ b/src/lib/services/skincraft_inventory_targets.ts
@@ -1,14 +1,15 @@
-import type {CAppwideInventory, CInventory, InventoryAsset, rgAssetProperty} from '../types/steam';
+import type {CAppwideInventory, CInventory, InventoryAsset, rgAsset, rgAssetProperty} from '../types/steam';
 import type {ItemInfo} from '../bridge/handlers/fetch_inspect_info';
 import {ContextId} from '../types/steam_constants';
 import {isCAppwideInventory} from '../utils/checkers';
-import {formatFloatWithRank, formatSeed, isSkin} from '../utils/skin';
+import {formatFloatWithRank, formatSeed, isAgent, isCharm, isPatch, isSkin, isSticker} from '../utils/skin';
 import {steamEconomyImageUrl} from '../utils/steam_images';
 import {gFloatFetcher} from './float_fetcher';
 import {
     HEX_COLOR_PATTERN,
     MAX_SKINCRAFT_INVENTORY_TARGETS,
     SKINCRAFT_INSPECT_PATTERN,
+    STEAM_INSPECT_URL_PATTERN,
 } from './skincraft_viewer_protocol';
 import type {SkinCraftItem} from './skincraft_viewer_protocol';
 
@@ -22,17 +23,32 @@ function getAssetProperties(asset: InventoryAsset, fallbackProperties: rgAssetPr
     return fallbackProperties;
 }
 
+/** Item types SkinCraft renders (weapons and gloves are both matched by `isSkin`). */
+function isSkinCraftRenderable(description: rgAsset): boolean {
+    if (isSkin(description)) return true;
+    // Half-hydrated descriptions may lack `type`, which the predicates below dereference.
+    if (typeof description.type !== 'string') return false;
+    return isSticker(description) || isCharm(description) || isPatch(description) || isAgent(description);
+}
+
 function getSkinCraftInspect(
     asset: InventoryAsset | undefined,
     fallbackProperties: rgAssetProperty[]
 ): string | undefined {
-    if (!asset?.description || !isSkin(asset.description)) return;
+    if (!asset?.description || !isSkinCraftRenderable(asset.description)) return;
 
     return (
         getAssetProperties(asset, fallbackProperties)
             .find((property) => property.propertyid === 6)
             ?.string_value?.trim() || undefined
     );
+}
+
+/** The asset's `steam://` inspect launch link — Steam templates the masked hex slot as `%propid:6%`. */
+function getSteamInspectUrl(asset: InventoryAsset, inspect: string): string | undefined {
+    const link = asset.description.actions?.find((action) => action.link.includes('%propid:6%'))?.link;
+    const url = link?.replace('%propid:6%', inspect);
+    return url && STEAM_INSPECT_URL_PATTERN.test(url) ? url : undefined;
 }
 
 export function toSkinCraftItem(
@@ -51,6 +67,7 @@ export function toSkinCraftItem(
     const backgroundColor = asset.description.background_color;
     return {
         inspect,
+        inspectUrl: getSteamInspectUrl(asset, inspect),
         name: asset.description.market_hash_name,
         iconUrl: icon ? steamEconomyImageUrl(icon) : undefined,
         assetId: asset.assetid,

--- a/src/lib/services/skincraft_inventory_targets.ts
+++ b/src/lib/services/skincraft_inventory_targets.ts
@@ -31,23 +31,35 @@ function isSkinCraftRenderable(description: rgAsset): boolean {
     return isSticker(description) || isCharm(description) || isPatch(description) || isAgent(description);
 }
 
+const MASKED_ACTION_PATTERN = /\+csgo_econ_action_preview%20(%propid:6%|[0-9a-f]{40,8192})$/i;
+
+/** The description's masked inspect action. Steam ships the hex two ways: as asset
+ *  property 6 with a `%propid:6%` slot in the link (skins), or embedded directly in
+ *  the link (stickers). */
+function getMaskedInspectAction(description: rgAsset): {link: string; embeddedHex?: string} | undefined {
+    for (const action of description.actions ?? []) {
+        const hex = MASKED_ACTION_PATTERN.exec(action.link)?.[1];
+        if (hex) return {link: action.link, embeddedHex: hex === '%propid:6%' ? undefined : hex};
+    }
+    return undefined;
+}
+
 function getSkinCraftInspect(
     asset: InventoryAsset | undefined,
     fallbackProperties: rgAssetProperty[]
 ): string | undefined {
     if (!asset?.description || !isSkinCraftRenderable(asset.description)) return;
 
-    return (
-        getAssetProperties(asset, fallbackProperties)
-            .find((property) => property.propertyid === 6)
-            ?.string_value?.trim() || undefined
-    );
+    const property = getAssetProperties(asset, fallbackProperties)
+        .find((property) => property.propertyid === 6)
+        ?.string_value?.trim();
+    return property || getMaskedInspectAction(asset.description)?.embeddedHex;
 }
 
-/** The asset's `steam://` inspect launch link — Steam templates the masked hex slot as `%propid:6%`. */
+/** The asset's `steam://` inspect launch link, with any `%propid:6%` slot filled with the masked hex. */
 function getSteamInspectUrl(asset: InventoryAsset, inspect: string): string | undefined {
-    const link = asset.description.actions?.find((action) => action.link.includes('%propid:6%'))?.link;
-    const url = link?.replace('%propid:6%', inspect);
+    const action = getMaskedInspectAction(asset.description);
+    const url = action?.embeddedHex ? action.link : action?.link.replace('%propid:6%', inspect);
     return url && STEAM_INSPECT_URL_PATTERN.test(url) ? url : undefined;
 }
 

--- a/src/lib/services/skincraft_viewer_protocol.test.ts
+++ b/src/lib/services/skincraft_viewer_protocol.test.ts
@@ -8,6 +8,7 @@ import type {SkinCraftItem} from './skincraft_viewer_protocol';
 
 const target: SkinCraftItem = {
     inspect: 'a'.repeat(80),
+    inspectUrl: `steam://rungame/730/76561202255233023/+csgo_econ_action_preview%20${'a'.repeat(80)}`,
     name: 'AK-47 | Redline',
     iconUrl: 'https://community.akamai.steamstatic.com/economy/image/example/330x192',
     assetId: '12345678901234567890',
@@ -25,6 +26,14 @@ describe('SkinCraft viewer open messages', () => {
                 type: 'open',
                 target,
                 inventory: [target],
+            })
+        ).toBe(true);
+        expect(
+            isOpenSkinCraftViewerMessage({
+                source: SKINCRAFT_VIEWER_MESSAGE_SOURCE,
+                type: 'open',
+                target: {...target, inspectUrl: undefined},
+                inventory: [],
             })
         ).toBe(true);
     });
@@ -52,6 +61,22 @@ describe('SkinCraft viewer open messages', () => {
                 type: 'open',
                 target,
                 inventory: [{...target, rarityColor: 'not-a-color'}],
+            })
+        ).toBe(false);
+        expect(
+            isOpenSkinCraftViewerMessage({
+                source: SKINCRAFT_VIEWER_MESSAGE_SOURCE,
+                type: 'open',
+                target: {...target, inspectUrl: 'https://example.com/inspect'},
+                inventory: [],
+            })
+        ).toBe(false);
+        expect(
+            isOpenSkinCraftViewerMessage({
+                source: SKINCRAFT_VIEWER_MESSAGE_SOURCE,
+                type: 'open',
+                target: {...target, inspectUrl: 'steam://uninstall/730'},
+                inventory: [],
             })
         ).toBe(false);
     });

--- a/src/lib/services/skincraft_viewer_protocol.ts
+++ b/src/lib/services/skincraft_viewer_protocol.ts
@@ -12,7 +12,7 @@ const ASSET_ID_PATTERN = /^\d{1,32}$/;
 /** An item as it crosses the page → content-script boundary. */
 export type SkinCraftItem = {
     inspect: string;
-    /** The item's own `steam://` launch link, for Inspect clicks forwarded out of the embed. */
+    /** The `steam://` launch link; `inspect` is the masked hex on its own. */
     inspectUrl?: string;
     name: string;
     iconUrl?: string;

--- a/src/lib/services/skincraft_viewer_protocol.ts
+++ b/src/lib/services/skincraft_viewer_protocol.ts
@@ -6,7 +6,7 @@ export const MAX_SKINCRAFT_INVENTORY_TARGETS = 2_000;
 export const SKINCRAFT_INSPECT_PATTERN = /^[0-9a-f]{40,8192}$/i;
 export const HEX_COLOR_PATTERN = /^[0-9a-f]{6}$/i;
 export const STEAM_INSPECT_URL_PATTERN =
-    /^steam:\/\/rungame\/730\/\d{1,20}\/\+csgo_econ_action_preview%20[0-9a-f]{40,8192}$/i;
+    /^steam:\/\/(?:run|rungame)\/730\/\d{0,20}\/\+csgo_econ_action_preview%20[0-9a-f]{40,8192}$/i;
 const ASSET_ID_PATTERN = /^\d{1,32}$/;
 
 /** An item as it crosses the page → content-script boundary. */

--- a/src/lib/services/skincraft_viewer_protocol.ts
+++ b/src/lib/services/skincraft_viewer_protocol.ts
@@ -5,11 +5,15 @@ export const MAX_SKINCRAFT_INVENTORY_TARGETS = 2_000;
 
 export const SKINCRAFT_INSPECT_PATTERN = /^[0-9a-f]{40,8192}$/i;
 export const HEX_COLOR_PATTERN = /^[0-9a-f]{6}$/i;
+export const STEAM_INSPECT_URL_PATTERN =
+    /^steam:\/\/rungame\/730\/\d{1,20}\/\+csgo_econ_action_preview%20[0-9a-f]{40,8192}$/i;
 const ASSET_ID_PATTERN = /^\d{1,32}$/;
 
 /** An item as it crosses the page → content-script boundary. */
 export type SkinCraftItem = {
     inspect: string;
+    /** The item's own `steam://` launch link, for Inspect clicks forwarded out of the embed. */
+    inspectUrl?: string;
     name: string;
     iconUrl?: string;
     assetId?: string;
@@ -36,6 +40,7 @@ function isSkinCraftItemShape(data: unknown): data is SkinCraftItem {
     const item = data as Partial<SkinCraftItem>;
     return (
         typeof item.inspect === 'string' &&
+        (item.inspectUrl === undefined || typeof item.inspectUrl === 'string') &&
         typeof item.name === 'string' &&
         (item.assetId === undefined || typeof item.assetId === 'string') &&
         (item.seed === undefined || typeof item.seed === 'string') &&
@@ -50,6 +55,7 @@ function isSkinCraftItemShape(data: unknown): data is SkinCraftItem {
 function isValidSkinCraftItem(item: SkinCraftItem): boolean {
     return (
         SKINCRAFT_INSPECT_PATTERN.test(item.inspect) &&
+        (item.inspectUrl === undefined || STEAM_INSPECT_URL_PATTERN.test(item.inspectUrl)) &&
         item.name.length <= 512 &&
         (item.assetId === undefined || ASSET_ID_PATTERN.test(item.assetId)) &&
         (item.seed === undefined || item.seed.length <= 64) &&

--- a/src/lib/utils/skin.ts
+++ b/src/lib/utils/skin.ts
@@ -156,7 +156,8 @@ export function isPin(asset: rgAsset): boolean {
 }
 
 function isAbstractType(asset: rgAsset, type: string, internalName: string): boolean {
-    if (asset.type.endsWith(type)) {
+    // Half-hydrated descriptions can arrive without `type`, despite the declared shape.
+    if (typeof asset.type === 'string' && asset.type.endsWith(type)) {
         return true;
     }
 


### PR DESCRIPTION
## Summary
- Opens the SkinCraft 3D button on inventory pages to stickers, patches, charms and agents
  alongside weapons/gloves. The embed protocol is inspect-based, so this is extension-side
  gating only — the item kind rides inside the masked inspect hex.
- Reads the masked hex from both layouts Steam ships: asset property 6 with a `%propid:6%`
  slot in the action link, or the hex embedded in the link itself. Accepts the inventory
  `steam://run/730//` and market `steam://rungame/730/<id>/` forms. The launch link is rebuilt
  around the hex the viewer renders, so the two can't describe different items.
- Adds an `inspect-requested` embed event: the sandboxed iframe can't launch `steam://`, so it
  forwards the click and the extension launches the item on screen. No URL crosses the bridge —
  `SkinCraftItem.inspectUrl` is pattern-pinned at the page → content-script boundary and
  re-checked before navigation.

`isAbstractType` no longer dereferences `asset.type` unconditionally. This is shared code:
`isCharm`, `isAgent`, `isSticker`, `isPatch`, `isCase`, `isMusicKit` and `isPin` now match on
the tag branch where a description without `type` previously threw.

Merge order: the SkinCraft embed change must deploy first, or the new 3D tabs fail to load.

## Validation
- `npm test`
- `npm run lint`
- `npm run checkformat`
- `npm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches postMessage boundaries, `window.location` navigation to `steam://`, and shared item-type helpers; embed must deploy first or new tabs may fail to load.
> 
> **Overview**
> Extends the SkinCraft 3D inventory viewer to **stickers, patches, charms, and agents** (not only weapons/gloves), with inspect hex read from asset property 6 and/or Steam’s masked `Inspect in Game` actions (`%propid:6%` or inline hex). Items now carry an optional **`inspectUrl`** (`steam://…`) rebuilt from the rendered hex and validated at the viewer protocol boundary.
> 
> Adds embed protocol event **`inspect-requested`**: the sandboxed iframe signals inspect clicks and the extension opens the pinned `steam://` link for the **currently loaded** item (only after `loaded`, with `STEAM_INSPECT_URL_PATTERN`).
> 
> **`isAbstractType`** no longer assumes `asset.type` is always present (tag-based matching for half-hydrated Steam descriptions). Dev **`skincraft_embed_origin`** points at `https://beta.skincraft.gg` instead of localhost.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4d2893d77e40331062f0bba790b1ea6d0e3534a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->